### PR TITLE
feat: add role support for clients and professionals

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+PORT=4000
+DATABASE_URL=postgresql://user:password@localhost:5432/pi_banho_e_tosa
+JWT_SECRET=change-me
+JWT_EXPIRES_IN=1d

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["standard"],
+  "overrides": [],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,36 @@
+# Backend - Sistema de Banho e Tosa
+
+## Scripts
+
+- `npm install` — instala dependências.
+- `npm run dev` — inicia servidor com nodemon.
+- `npm start` — inicia servidor em produção.
+- `npm run lint` — executa ESLint.
+
+## Estrutura
+
+```
+src/
+  config/        # Conexão com banco de dados
+  controllers/   # Camada de controle das rotas
+  services/      # Regras de negócio
+  routes/        # Definição das rotas
+  middlewares/   # Middlewares globais
+  utils/         # Utilitários (hash, notificações, disponibilidade)
+  db/schema.sql  # Script inicial de banco de dados
+```
+
+## Variáveis de ambiente
+
+Crie um arquivo `.env` baseado em `.env.example` com:
+
+```
+PORT=4000
+DATABASE_URL=postgresql://user:password@localhost:5432/pi_banho_e_tosa
+JWT_SECRET=sua-chave
+JWT_EXPIRES_IN=1d
+```
+
+## Banco de dados
+
+Execute o script `src/db/schema.sql` no PostgreSQL para criar as tabelas necessárias.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "pi-banho-e-tosa-backend",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/server.js",
+  "scripts": {
+    "dev": "nodemon src/server.js",
+    "start": "node src/server.js",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "dayjs": "^1.11.10",
+    "dotenv": "^16.4.1",
+    "express": "^4.18.2",
+    "express-async-errors": "^3.1.1",
+    "jsonwebtoken": "^9.0.2",
+    "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-promise": "^6.1.1",
+    "nodemon": "^3.0.2"
+  }
+}

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,24 @@
+import 'express-async-errors'
+import express from 'express'
+import cors from 'cors'
+import dotenv from 'dotenv'
+
+import router from './routes/index.js'
+import { errorHandler } from './middlewares/errorHandler.js'
+
+dotenv.config()
+
+const app = express()
+
+app.use(cors())
+app.use(express.json())
+
+app.get('/', (req, res) => {
+  res.json({ status: 'API Banho e Tosa operante' })
+})
+
+app.use('/api', router)
+
+app.use(errorHandler)
+
+export default app

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -1,0 +1,23 @@
+import dotenv from 'dotenv'
+import pkg from 'pg'
+
+const { Pool } = pkg
+
+dotenv.config()
+
+const connectionString = process.env.DATABASE_URL
+
+export const pool = new Pool({
+  connectionString,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+})
+
+export async function query (text, params) {
+  const start = Date.now()
+  const res = await pool.query(text, params)
+  const duration = Date.now() - start
+  if (process.env.NODE_ENV !== 'test') {
+    console.log('executed query', { text, duration, rows: res.rowCount })
+  }
+  return res
+}

--- a/backend/src/constants/roles.js
+++ b/backend/src/constants/roles.js
@@ -1,0 +1,6 @@
+export const UserRole = {
+  CLIENTE: 'cliente',
+  PROFISSIONAL: 'profissional'
+}
+
+export const AllowedRoles = Object.values(UserRole)

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -1,0 +1,6 @@
+import { obterDashboard } from '../services/adminService.js'
+
+export async function dashboard (req, res) {
+  const dados = await obterDashboard()
+  res.json(dados)
+}

--- a/backend/src/controllers/agendamentosController.js
+++ b/backend/src/controllers/agendamentosController.js
@@ -1,0 +1,94 @@
+import {
+  obterSlotsDisponiveis,
+  criarAgendamento,
+  listarAgendamentosCliente,
+  listarAgendamentosProfissional,
+  cancelarAgendamento,
+  reagendar,
+  registrarObservacoes,
+  listarHistorico,
+  registrarPresenca
+} from '../services/agendamentosService.js'
+
+export async function slotsDisponiveis (req, res) {
+  const { idProfissional, data, idServico } = req.query
+  if (!idProfissional || !data) {
+    return res.status(400).json({ error: 'Profissional e data são obrigatórios' })
+  }
+
+  const slots = await obterSlotsDisponiveis({ idProfissional, data, idServico })
+  res.json(slots)
+}
+
+export async function criar (req, res) {
+  const { idCliente, idAnimal, idServico, idProfissional, dataHorario, status, observacoes } = req.body
+  const agendamento = await criarAgendamento({
+    idCliente,
+    idAnimal,
+    idServico,
+    idProfissional,
+    dataHorario,
+    status,
+    observacoes
+  })
+  res.status(201).json(agendamento)
+}
+
+export async function listarCliente (req, res) {
+  const { idCliente } = req.params
+  const agendamentos = await listarAgendamentosCliente(idCliente)
+  res.json(agendamentos)
+}
+
+export async function listarProfissional (req, res) {
+  const { idProfissional } = req.params
+  const { periodo, referencia } = req.query
+  const agendamentos = await listarAgendamentosProfissional({ idProfissional, periodo, referencia })
+  res.json(agendamentos)
+}
+
+export async function cancelar (req, res) {
+  const { idAgendamento } = req.params
+  const { motivo } = req.body
+  if (!motivo) {
+    return res.status(400).json({ error: 'Informe o motivo do cancelamento' })
+  }
+
+  const resultado = await cancelarAgendamento({ idAgendamento, motivo })
+  res.json(resultado)
+}
+
+export async function reagendarController (req, res) {
+  const { idAgendamento } = req.params
+  const { novoHorario } = req.body
+  if (!novoHorario) {
+    return res.status(400).json({ error: 'Informe o novo horário' })
+  }
+
+  const agendamento = await reagendar({ idAgendamento, novoHorario })
+  res.json(agendamento)
+}
+
+export async function registrarObs (req, res) {
+  const { idAgendamento } = req.params
+  const { idProfissional, observacoes } = req.body
+  if (!idProfissional || !observacoes) {
+    return res.status(400).json({ error: 'Profissional e observações são obrigatórios' })
+  }
+
+  const resultado = await registrarObservacoes({ idAgendamento, idProfissional, observacoes })
+  res.json(resultado)
+}
+
+export async function historico (req, res) {
+  const { idCliente, idAnimal } = req.query
+  const historico = await listarHistorico({ idCliente, idAnimal })
+  res.json(historico)
+}
+
+export async function confirmarPresenca (req, res) {
+  const { idAgendamento } = req.params
+  const { confirmado } = req.body
+  const resultado = await registrarPresenca({ idAgendamento, confirmado })
+  res.json(resultado)
+}

--- a/backend/src/controllers/animaisController.js
+++ b/backend/src/controllers/animaisController.js
@@ -1,0 +1,17 @@
+import { cadastrarAnimal, listarAnimaisPorCliente } from '../services/animaisService.js'
+
+export async function criar (req, res) {
+  const { idCliente, nome, especie, porte, idade, observacoes } = req.body
+  if (!idCliente || !nome || !especie) {
+    return res.status(400).json({ error: 'Cliente, nome e espécie são obrigatórios' })
+  }
+
+  const animal = await cadastrarAnimal({ idCliente, nome, especie, porte, idade, observacoes })
+  res.status(201).json(animal)
+}
+
+export async function listarPorCliente (req, res) {
+  const { idCliente } = req.params
+  const animais = await listarAnimaisPorCliente(idCliente)
+  res.json(animais)
+}

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,42 @@
+import { autenticarUsuario, recuperarSenha, redefinirSenha } from '../services/authService.js'
+import { AllowedRoles } from '../constants/roles.js'
+import { sendNotification, NotificationType } from '../utils/notifications.js'
+
+export async function login (req, res) {
+  const { email, senha, role } = req.body
+  if (!email || !senha || !role) {
+    return res.status(400).json({ error: 'Informe e-mail, senha e perfil de acesso' })
+  }
+
+  if (!AllowedRoles.includes(role)) {
+    return res.status(400).json({ error: 'Perfil inválido' })
+  }
+
+  const resultado = await autenticarUsuario({ email, senha, role })
+  res.json(resultado)
+}
+
+export async function solicitarRecuperacao (req, res) {
+  const { email } = req.body
+  if (!email) {
+    return res.status(400).json({ error: 'Informe o e-mail cadastrado' })
+  }
+
+  const { token } = await recuperarSenha({ email })
+  sendNotification({
+    type: NotificationType.PASSWORD_RECOVERY,
+    recipient: email,
+    message: `Token de recuperação: ${token}`
+  })
+  res.json({ mensagem: 'Token de recuperação enviado' })
+}
+
+export async function redefinir (req, res) {
+  const { token, novaSenha } = req.body
+  if (!token || !novaSenha) {
+    return res.status(400).json({ error: 'Token e nova senha são obrigatórios' })
+  }
+
+  await redefinirSenha({ token, novaSenha })
+  res.json({ mensagem: 'Senha atualizada com sucesso' })
+}

--- a/backend/src/controllers/clientesController.js
+++ b/backend/src/controllers/clientesController.js
@@ -1,0 +1,16 @@
+import { criarCliente, listarClientes } from '../services/clientesService.js'
+
+export async function listar (req, res) {
+  const clientes = await listarClientes()
+  res.json(clientes)
+}
+
+export async function criar (req, res) {
+  const { nome, telefone, email, senha } = req.body
+  if (!nome || !telefone || !email || !senha) {
+    return res.status(400).json({ error: 'Campos obrigatórios não preenchidos' })
+  }
+
+  const cliente = await criarCliente({ nome, telefone, email, senha })
+  res.status(201).json(cliente)
+}

--- a/backend/src/controllers/profissionaisController.js
+++ b/backend/src/controllers/profissionaisController.js
@@ -1,0 +1,55 @@
+import {
+  listarProfissionais,
+  definirDisponibilidade,
+  registrarIndisponibilidade,
+  listarDisponibilidades,
+  listarIndisponibilidades,
+  criarProfissional
+} from '../services/profissionaisService.js'
+
+export async function listar (req, res) {
+  const profissionais = await listarProfissionais()
+  res.json(profissionais)
+}
+
+export async function criar (req, res) {
+  const { nome, telefone, email, senha, ativo } = req.body
+  if (!nome || !telefone || !email || !senha) {
+    return res.status(400).json({ error: 'Campos obrigatórios não preenchidos' })
+  }
+
+  const profissional = await criarProfissional({ nome, telefone, email, senha, ativo })
+  res.status(201).json(profissional)
+}
+
+export async function salvarDisponibilidade (req, res) {
+  const { idProfissional, diaSemana, horaInicio, horaFim } = req.body
+  if (!idProfissional || diaSemana === undefined || !horaInicio || !horaFim) {
+    return res.status(400).json({ error: 'Campos obrigatórios não preenchidos' })
+  }
+
+  const disponibilidade = await definirDisponibilidade({ idProfissional, diaSemana, horaInicio, horaFim })
+  res.status(201).json(disponibilidade)
+}
+
+export async function salvarIndisponibilidade (req, res) {
+  const { idProfissional, dataInicio, dataFim, motivo } = req.body
+  if (!idProfissional || !dataInicio || !dataFim) {
+    return res.status(400).json({ error: 'Campos obrigatórios não preenchidos' })
+  }
+
+  const indisponibilidade = await registrarIndisponibilidade({ idProfissional, dataInicio, dataFim, motivo })
+  res.status(201).json(indisponibilidade)
+}
+
+export async function listarDisponibilidade (req, res) {
+  const { idProfissional } = req.params
+  const disponibilidades = await listarDisponibilidades(idProfissional)
+  res.json(disponibilidades)
+}
+
+export async function listarIndisponibilidade (req, res) {
+  const { idProfissional } = req.params
+  const indisponibilidades = await listarIndisponibilidades(idProfissional)
+  res.json(indisponibilidades)
+}

--- a/backend/src/controllers/servicosController.js
+++ b/backend/src/controllers/servicosController.js
@@ -1,0 +1,34 @@
+import {
+  listarServicos,
+  criarServico,
+  atualizarServico,
+  removerServico
+} from '../services/servicosService.js'
+
+export async function listar (req, res) {
+  const servicos = await listarServicos()
+  res.json(servicos)
+}
+
+export async function criar (req, res) {
+  const { nomeServico, descricao, valor, tempoEstimado } = req.body
+  if (!nomeServico || !tempoEstimado) {
+    return res.status(400).json({ error: 'Nome e tempo estimado são obrigatórios' })
+  }
+
+  const servico = await criarServico({ nomeServico, descricao, valor, tempoEstimado })
+  res.status(201).json(servico)
+}
+
+export async function atualizar (req, res) {
+  const { idServico } = req.params
+  const { nomeServico, descricao, valor, tempoEstimado } = req.body
+  const servico = await atualizarServico(idServico, { nomeServico, descricao, valor, tempoEstimado })
+  res.json(servico)
+}
+
+export async function remover (req, res) {
+  const { idServico } = req.params
+  await removerServico(idServico)
+  res.status(204).send()
+}

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -1,0 +1,102 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'status_agendamento'
+  ) THEN
+    CREATE TYPE status_agendamento AS ENUM ('pendente', 'confirmado', 'cancelado', 'concluido', 'ausente');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS clientes (
+  id_cliente UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  nome VARCHAR(150) NOT NULL,
+  telefone VARCHAR(20) NOT NULL,
+  email VARCHAR(150) NOT NULL UNIQUE,
+  senha_hash TEXT NOT NULL,
+  data_cadastro TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS profissionais (
+  id_profissional UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  nome VARCHAR(150) NOT NULL,
+  telefone VARCHAR(20),
+  email VARCHAR(150) UNIQUE,
+  senha_hash TEXT,
+  ativo BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE IF NOT EXISTS animais (
+  id_animal UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id_cliente UUID NOT NULL REFERENCES clientes(id_cliente) ON DELETE CASCADE,
+  nome VARCHAR(120) NOT NULL,
+  especie VARCHAR(80) NOT NULL,
+  porte VARCHAR(50),
+  idade INTEGER,
+  observacoes TEXT
+);
+
+CREATE TABLE IF NOT EXISTS servicos (
+  id_servico UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  nome_servico VARCHAR(150) NOT NULL,
+  descricao TEXT,
+  valor NUMERIC(10,2),
+  tempo_estimado INTEGER NOT NULL DEFAULT 60
+);
+
+CREATE TABLE IF NOT EXISTS agendamentos (
+  id_agendamento UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id_cliente UUID NOT NULL REFERENCES clientes(id_cliente) ON DELETE CASCADE,
+  id_animal UUID NOT NULL REFERENCES animais(id_animal) ON DELETE CASCADE,
+  id_servico UUID NOT NULL REFERENCES servicos(id_servico),
+  id_profissional UUID NOT NULL REFERENCES profissionais(id_profissional),
+  data_horario TIMESTAMPTZ NOT NULL,
+  status status_agendamento NOT NULL DEFAULT 'pendente',
+  observacoes TEXT,
+  criado_em TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  atualizado_em TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS historico_atendimentos (
+  id_historico UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id_agendamento UUID NOT NULL REFERENCES agendamentos(id_agendamento) ON DELETE CASCADE UNIQUE,
+  id_profissional UUID NOT NULL REFERENCES profissionais(id_profissional),
+  data_conclusao TIMESTAMPTZ NOT NULL,
+  observacoes TEXT
+);
+
+CREATE TABLE IF NOT EXISTS cancelamentos (
+  id_cancelamento UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id_agendamento UUID NOT NULL REFERENCES agendamentos(id_agendamento) ON DELETE CASCADE,
+  motivo TEXT NOT NULL,
+  data_cancelamento TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS tokens_recuperacao (
+  id_token UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id_cliente UUID NOT NULL REFERENCES clientes(id_cliente) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  expiracao TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS disponibilidades_profissionais (
+  id_disponibilidade UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id_profissional UUID NOT NULL REFERENCES profissionais(id_profissional) ON DELETE CASCADE,
+  dia_semana SMALLINT NOT NULL,
+  hora_inicio TIME NOT NULL,
+  hora_fim TIME NOT NULL,
+  UNIQUE (id_profissional, dia_semana, hora_inicio)
+);
+
+CREATE TABLE IF NOT EXISTS indisponibilidades_profissionais (
+  id_indisponibilidade UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id_profissional UUID NOT NULL REFERENCES profissionais(id_profissional) ON DELETE CASCADE,
+  data_inicio TIMESTAMPTZ NOT NULL,
+  data_fim TIMESTAMPTZ NOT NULL,
+  motivo TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agendamentos_profissional_data ON agendamentos (id_profissional, data_horario);
+CREATE INDEX IF NOT EXISTS idx_agendamentos_cliente ON agendamentos (id_cliente);
+CREATE INDEX IF NOT EXISTS idx_cancelamentos_agendamento ON cancelamentos (id_agendamento);

--- a/backend/src/middlewares/authMiddleware.js
+++ b/backend/src/middlewares/authMiddleware.js
@@ -1,0 +1,25 @@
+import jwt from 'jsonwebtoken'
+
+export function authenticate (roles = []) {
+  return (req, res, next) => {
+    const authHeader = req.headers.authorization
+    if (!authHeader) {
+      return res.status(401).json({ error: 'Token não fornecido' })
+    }
+
+    const [, token] = authHeader.split(' ')
+
+    try {
+      const payload = jwt.verify(token, process.env.JWT_SECRET)
+      req.user = payload
+
+      if (roles.length && !roles.includes(payload.role)) {
+        return res.status(403).json({ error: 'Acesso negado' })
+      }
+
+      next()
+    } catch (error) {
+      return res.status(401).json({ error: 'Token inválido' })
+    }
+  }
+}

--- a/backend/src/middlewares/errorHandler.js
+++ b/backend/src/middlewares/errorHandler.js
@@ -1,0 +1,6 @@
+export function errorHandler (err, req, res, next) {
+  console.error(err)
+  const status = err.status || 500
+  const message = err.message || 'Internal server error'
+  res.status(status).json({ error: message })
+}

--- a/backend/src/routes/admin.routes.js
+++ b/backend/src/routes/admin.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express'
+import { dashboard } from '../controllers/adminController.js'
+
+const router = Router()
+
+router.get('/dashboard', dashboard)
+
+export default router

--- a/backend/src/routes/agendamentos.routes.js
+++ b/backend/src/routes/agendamentos.routes.js
@@ -1,0 +1,26 @@
+import { Router } from 'express'
+import {
+  slotsDisponiveis,
+  criar,
+  listarCliente,
+  listarProfissional,
+  cancelar,
+  reagendarController,
+  registrarObs,
+  historico,
+  confirmarPresenca
+} from '../controllers/agendamentosController.js'
+
+const router = Router()
+
+router.get('/disponiveis', slotsDisponiveis)
+router.get('/clientes/:idCliente', listarCliente)
+router.get('/profissionais/:idProfissional', listarProfissional)
+router.get('/historico', historico)
+router.post('/', criar)
+router.post('/:idAgendamento/cancelar', cancelar)
+router.post('/:idAgendamento/reagendar', reagendarController)
+router.post('/:idAgendamento/observacoes', registrarObs)
+router.post('/:idAgendamento/presenca', confirmarPresenca)
+
+export default router

--- a/backend/src/routes/animais.routes.js
+++ b/backend/src/routes/animais.routes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express'
+import { criar, listarPorCliente } from '../controllers/animaisController.js'
+
+const router = Router()
+
+router.post('/', criar)
+router.get('/cliente/:idCliente', listarPorCliente)
+
+export default router

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -1,0 +1,10 @@
+import { Router } from 'express'
+import { login, solicitarRecuperacao, redefinir } from '../controllers/authController.js'
+
+const router = Router()
+
+router.post('/login', login)
+router.post('/recovery', solicitarRecuperacao)
+router.post('/reset', redefinir)
+
+export default router

--- a/backend/src/routes/clientes.routes.js
+++ b/backend/src/routes/clientes.routes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express'
+import { criar, listar } from '../controllers/clientesController.js'
+
+const router = Router()
+
+router.get('/', listar)
+router.post('/', criar)
+
+export default router

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,0 +1,21 @@
+import { Router } from 'express'
+
+import clientesRoutes from './clientes.routes.js'
+import authRoutes from './auth.routes.js'
+import animaisRoutes from './animais.routes.js'
+import agendamentosRoutes from './agendamentos.routes.js'
+import profissionaisRoutes from './profissionais.routes.js'
+import servicosRoutes from './servicos.routes.js'
+import adminRoutes from './admin.routes.js'
+
+const router = Router()
+
+router.use('/clientes', clientesRoutes)
+router.use('/auth', authRoutes)
+router.use('/animais', animaisRoutes)
+router.use('/agendamentos', agendamentosRoutes)
+router.use('/profissionais', profissionaisRoutes)
+router.use('/servicos', servicosRoutes)
+router.use('/admin', adminRoutes)
+
+export default router

--- a/backend/src/routes/profissionais.routes.js
+++ b/backend/src/routes/profissionais.routes.js
@@ -1,0 +1,20 @@
+import { Router } from 'express'
+import {
+  listar,
+  criar,
+  salvarDisponibilidade,
+  salvarIndisponibilidade,
+  listarDisponibilidade,
+  listarIndisponibilidade
+} from '../controllers/profissionaisController.js'
+
+const router = Router()
+
+router.get('/', listar)
+router.post('/', criar)
+router.post('/disponibilidades', salvarDisponibilidade)
+router.post('/indisponibilidades', salvarIndisponibilidade)
+router.get('/:idProfissional/disponibilidades', listarDisponibilidade)
+router.get('/:idProfissional/indisponibilidades', listarIndisponibilidade)
+
+export default router

--- a/backend/src/routes/servicos.routes.js
+++ b/backend/src/routes/servicos.routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express'
+import { listar, criar, atualizar, remover } from '../controllers/servicosController.js'
+
+const router = Router()
+
+router.get('/', listar)
+router.post('/', criar)
+router.put('/:idServico', atualizar)
+router.delete('/:idServico', remover)
+
+export default router

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,7 @@
+import app from './app.js'
+
+const PORT = process.env.PORT || 4000
+
+app.listen(PORT, () => {
+  console.log(`Servidor iniciado na porta ${PORT}`)
+})

--- a/backend/src/services/adminService.js
+++ b/backend/src/services/adminService.js
@@ -1,0 +1,25 @@
+import { query } from '../config/database.js'
+
+function parseTotal (rows) {
+  return Number(rows?.total) || 0
+}
+
+export async function obterDashboard () {
+  const [clientes, animais, servicos, agendamentos, cancelamentos, faltas] = await Promise.all([
+    query('SELECT COUNT(*)::int as total FROM clientes').then(r => r.rows[0]),
+    query('SELECT COUNT(*)::int as total FROM animais').then(r => r.rows[0]),
+    query('SELECT COUNT(*)::int as total FROM servicos').then(r => r.rows[0]),
+    query('SELECT COUNT(*)::int as total FROM agendamentos').then(r => r.rows[0]),
+    query('SELECT COUNT(*)::int as total FROM cancelamentos').then(r => r.rows[0]),
+    query("SELECT COUNT(*)::int as total FROM agendamentos WHERE status = 'ausente'").then(r => r.rows[0])
+  ])
+
+  return {
+    totalClientes: parseTotal(clientes),
+    totalAnimais: parseTotal(animais),
+    totalServicos: parseTotal(servicos),
+    totalAgendamentos: parseTotal(agendamentos),
+    totalCancelamentos: parseTotal(cancelamentos),
+    totalFaltas: parseTotal(faltas)
+  }
+}

--- a/backend/src/services/agendamentosService.js
+++ b/backend/src/services/agendamentosService.js
@@ -1,0 +1,392 @@
+import dayjs from 'dayjs'
+import { query } from '../config/database.js'
+import { generateTimeSlots, filterUnavailableSlots } from '../utils/availability.js'
+import { obterServico } from './servicosService.js'
+import { obterAnimal } from './animaisService.js'
+import { obterProfissional } from './profissionaisService.js'
+import { NotificationType, sendNotification } from '../utils/notifications.js'
+
+export const AGENDAMENTO_STATUS = Object.freeze({
+  PENDENTE: 'pendente',
+  CONFIRMADO: 'confirmado',
+  CANCELADO: 'cancelado',
+  CONCLUIDO: 'concluido',
+  AUSENTE: 'ausente'
+})
+
+function calcularFim (inicio, duracaoMinutos) {
+  const duration = Number(duracaoMinutos) || 60
+  return dayjs(inicio).add(duration, 'minute')
+}
+
+function intervaloSobreposto ({ inicioA, fimA, inicioB, fimB }) {
+  return dayjs(inicioA).isBefore(fimB) && dayjs(fimA).isAfter(inicioB)
+}
+
+async function buscarAgendamento (idAgendamento) {
+  const { rows } = await query('SELECT * FROM agendamentos WHERE id_agendamento = $1', [idAgendamento])
+  return rows[0]
+}
+
+async function validarDisponibilidade ({ idProfissional, inicioISO, fimISO, ignorarAgendamentoId }) {
+  const { rows } = await query(
+    `SELECT a.id_agendamento, a.data_horario, COALESCE(s.tempo_estimado, 60) as tempo_estimado
+       FROM agendamentos a
+  LEFT JOIN servicos s ON s.id_servico = a.id_servico
+      WHERE a.id_profissional = $1
+        AND a.status NOT IN ('cancelado', 'ausente')
+        AND DATE(a.data_horario) = DATE($2)`,
+    [idProfissional, inicioISO]
+  )
+
+  const existeConflito = rows.some(row => {
+    if (ignorarAgendamentoId && row.id_agendamento === ignorarAgendamentoId) {
+      return false
+    }
+    const inicioExistente = dayjs(row.data_horario)
+    const fimExistente = calcularFim(inicioExistente, row.tempo_estimado)
+    return intervaloSobreposto({ inicioA: inicioExistente, fimA: fimExistente, inicioB: dayjs(inicioISO), fimB: dayjs(fimISO) })
+  })
+
+  if (existeConflito) {
+    const error = new Error('Horário indisponível para o profissional selecionado')
+    error.status = 400
+    throw error
+  }
+}
+
+export async function listarAgendamentosCliente (idCliente) {
+  const { rows } = await query(
+    `SELECT a.*, s.nome_servico, p.nome as profissional, an.nome as animal
+       FROM agendamentos a
+ INNER JOIN servicos s ON s.id_servico = a.id_servico
+ INNER JOIN profissionais p ON p.id_profissional = a.id_profissional
+ INNER JOIN animais an ON an.id_animal = a.id_animal
+      WHERE a.id_cliente = $1
+      ORDER BY a.data_horario DESC`,
+    [idCliente]
+  )
+  return rows
+}
+
+export async function listarAgendamentosProfissional ({ idProfissional, periodo = 'dia', referencia }) {
+  const base = dayjs(referencia || new Date())
+  let inicio
+  let fim
+
+  switch (periodo) {
+    case 'semana':
+      inicio = base.startOf('week')
+      fim = base.endOf('week')
+      break
+    case 'mes':
+      inicio = base.startOf('month')
+      fim = base.endOf('month')
+      break
+    default:
+      inicio = base.startOf('day')
+      fim = base.endOf('day')
+  }
+
+  const { rows } = await query(
+    `SELECT a.*, c.nome as cliente, an.nome as animal, s.nome_servico
+       FROM agendamentos a
+ INNER JOIN clientes c ON c.id_cliente = a.id_cliente
+ INNER JOIN animais an ON an.id_animal = a.id_animal
+ INNER JOIN servicos s ON s.id_servico = a.id_servico
+      WHERE a.id_profissional = $1
+        AND a.data_horario BETWEEN $2 AND $3
+      ORDER BY a.data_horario ASC`,
+    [idProfissional, inicio.toISOString(), fim.toISOString()]
+  )
+  return rows
+}
+
+export async function obterSlotsDisponiveis ({ idProfissional, data, idServico }) {
+  const profissional = await obterProfissional(idProfissional)
+  if (!profissional) {
+    const error = new Error('Profissional não encontrado')
+    error.status = 404
+    throw error
+  }
+
+  const servico = idServico ? await obterServico(idServico) : null
+  const duracao = Number(servico?.tempo_estimado) || 60
+
+  const dia = dayjs(data)
+  const diaSemana = dia.day()
+
+  const { rows: disponibilidades } = await query(
+    `SELECT * FROM disponibilidades_profissionais
+      WHERE id_profissional = $1 AND dia_semana = $2`,
+    [idProfissional, diaSemana]
+  )
+
+  if (disponibilidades.length === 0) {
+    return []
+  }
+
+  const { rows: indisponibilidades } = await query(
+    `SELECT data_inicio, data_fim
+       FROM indisponibilidades_profissionais
+      WHERE id_profissional = $1
+        AND daterange(date(data_inicio), date(data_fim), '[]') @> $2::date`,
+    [idProfissional, dia.format('YYYY-MM-DD')]
+  )
+
+  const { rows: agendamentos } = await query(
+    `SELECT a.data_horario, COALESCE(s.tempo_estimado, 60) as tempo_estimado
+       FROM agendamentos a
+  LEFT JOIN servicos s ON s.id_servico = a.id_servico
+      WHERE a.id_profissional = $1
+        AND DATE(a.data_horario) = $2
+        AND a.status NOT IN ('cancelado', 'ausente')`,
+    [idProfissional, dia.format('YYYY-MM-DD')]
+  )
+
+  const takenIntervals = [
+    ...agendamentos.map(item => ({
+      start: dayjs(item.data_horario).toISOString(),
+      end: calcularFim(item.data_horario, item.tempo_estimado).toISOString()
+    })),
+    ...indisponibilidades.map(item => ({
+      start: dayjs(item.data_inicio).toISOString(),
+      end: dayjs(item.data_fim).toISOString()
+    }))
+  ]
+
+  const slots = disponibilidades.flatMap(item => {
+    const inicio = dayjs(`${dia.format('YYYY-MM-DD')}T${item.hora_inicio}`)
+    const fim = dayjs(`${dia.format('YYYY-MM-DD')}T${item.hora_fim}`)
+    return generateTimeSlots({ start: inicio, end: fim, durationMinutes: duracao })
+  })
+
+  return filterUnavailableSlots(slots, takenIntervals)
+}
+
+export async function criarAgendamento ({ idCliente, idAnimal, idServico, idProfissional, dataHorario, status = AGENDAMENTO_STATUS.PENDENTE, observacoes }) {
+  const animal = await obterAnimal(idAnimal)
+  if (!animal || animal.id_cliente !== idCliente) {
+    const error = new Error('Animal não pertence ao cliente informado')
+    error.status = 400
+    throw error
+  }
+
+  const servico = await obterServico(idServico)
+  if (!servico) {
+    const error = new Error('Serviço não encontrado')
+    error.status = 404
+    throw error
+  }
+
+  const inicio = dayjs(dataHorario)
+  const fim = calcularFim(inicio, servico.tempo_estimado)
+
+  await validarDisponibilidade({
+    idProfissional,
+    inicioISO: inicio.toISOString(),
+    fimISO: fim.toISOString()
+  })
+
+  const { rows } = await query(
+    `INSERT INTO agendamentos (id_cliente, id_animal, id_servico, id_profissional, data_horario, status, observacoes, criado_em, atualizado_em)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+     RETURNING *`,
+    [idCliente, idAnimal, idServico, idProfissional, inicio.toISOString(), status, observacoes]
+  )
+
+  sendNotification({
+    type: NotificationType.CONFIRMATION,
+    recipient: `cliente:${idCliente}`,
+    message: `Agendamento criado para ${inicio.format('DD/MM/YYYY HH:mm')}`
+  })
+
+  return rows[0]
+}
+
+export async function atualizarStatus ({ idAgendamento, status, observacoes }) {
+  const agendamento = await buscarAgendamento(idAgendamento)
+  if (!agendamento) {
+    const error = new Error('Agendamento não encontrado')
+    error.status = 404
+    throw error
+  }
+
+  const { rows } = await query(
+    `UPDATE agendamentos SET status = $1, observacoes = COALESCE($2, observacoes), atualizado_em = NOW()
+      WHERE id_agendamento = $3
+      RETURNING *`,
+    [status, observacoes, idAgendamento]
+  )
+
+  return rows[0]
+}
+
+export async function cancelarAgendamento ({ idAgendamento, motivo }) {
+  const agendamento = await buscarAgendamento(idAgendamento)
+  if (!agendamento) {
+    const error = new Error('Agendamento não encontrado')
+    error.status = 404
+    throw error
+  }
+
+  const diferencaHoras = dayjs(agendamento.data_horario).diff(dayjs(), 'hour', true)
+  if (diferencaHoras < 2) {
+    const error = new Error('Cancelamento permitido apenas com 2h de antecedência')
+    error.status = 400
+    throw error
+  }
+
+  await query('BEGIN')
+  try {
+    await query(
+      `UPDATE agendamentos SET status = $1, atualizado_em = NOW()
+        WHERE id_agendamento = $2`,
+      [AGENDAMENTO_STATUS.CANCELADO, idAgendamento]
+    )
+
+    await query(
+      `INSERT INTO cancelamentos (id_agendamento, motivo, data_cancelamento)
+       VALUES ($1, $2, NOW())`,
+      [idAgendamento, motivo]
+    )
+
+    await query('COMMIT')
+  } catch (error) {
+    await query('ROLLBACK')
+    throw error
+  }
+
+  sendNotification({
+    type: NotificationType.CANCELLATION,
+    recipient: `cliente:${agendamento.id_cliente}`,
+    message: `Agendamento ${idAgendamento} cancelado. Motivo: ${motivo}`
+  })
+
+  return { success: true }
+}
+
+export async function reagendar ({ idAgendamento, novoHorario }) {
+  const agendamento = await buscarAgendamento(idAgendamento)
+  if (!agendamento) {
+    const error = new Error('Agendamento não encontrado')
+    error.status = 404
+    throw error
+  }
+
+  const servico = await obterServico(agendamento.id_servico)
+  const inicio = dayjs(novoHorario)
+  const fim = calcularFim(inicio, servico.tempo_estimado)
+
+  await validarDisponibilidade({
+    idProfissional: agendamento.id_profissional,
+    inicioISO: inicio.toISOString(),
+    fimISO: fim.toISOString(),
+    ignorarAgendamentoId: idAgendamento
+  })
+
+  const { rows } = await query(
+    `UPDATE agendamentos SET data_horario = $1, status = $2, atualizado_em = NOW()
+      WHERE id_agendamento = $3
+      RETURNING *`,
+    [inicio.toISOString(), AGENDAMENTO_STATUS.CONFIRMADO, idAgendamento]
+  )
+
+  sendNotification({
+    type: NotificationType.RESCHEDULE,
+    recipient: `cliente:${agendamento.id_cliente}`,
+    message: `Novo horário confirmado para ${inicio.format('DD/MM/YYYY HH:mm')}`
+  })
+
+  return rows[0]
+}
+
+export async function registrarObservacoes ({ idAgendamento, idProfissional, observacoes }) {
+  const agendamento = await buscarAgendamento(idAgendamento)
+  if (!agendamento) {
+    const error = new Error('Agendamento não encontrado')
+    error.status = 404
+    throw error
+  }
+
+  if (agendamento.id_profissional !== idProfissional) {
+    const error = new Error('Apenas o profissional responsável pode registrar observações')
+    error.status = 403
+    throw error
+  }
+
+  await query('BEGIN')
+  try {
+    await query(
+      `UPDATE agendamentos SET observacoes = $1, status = $2, atualizado_em = NOW()
+        WHERE id_agendamento = $3`,
+      [observacoes, AGENDAMENTO_STATUS.CONCLUIDO, idAgendamento]
+    )
+
+    await query(
+      `INSERT INTO historico_atendimentos (id_agendamento, id_profissional, data_conclusao, observacoes)
+       VALUES ($1, $2, NOW(), $3)
+       ON CONFLICT (id_agendamento) DO UPDATE SET observacoes = EXCLUDED.observacoes, data_conclusao = EXCLUDED.data_conclusao`,
+      [idAgendamento, idProfissional, observacoes]
+    )
+
+    await query('COMMIT')
+  } catch (error) {
+    await query('ROLLBACK')
+    throw error
+  }
+
+  return { success: true }
+}
+
+export async function listarHistorico ({ idCliente, idAnimal }) {
+  const filtros = []
+  const params = []
+
+  if (idCliente) {
+    filtros.push(`c.id_cliente = $${params.length + 1}`)
+    params.push(idCliente)
+  }
+
+  if (idAnimal) {
+    filtros.push(`a.id_animal = $${params.length + 1}`)
+    params.push(idAnimal)
+  }
+
+  const whereClause = filtros.length ? `WHERE ${filtros.join(' AND ')}` : ''
+
+  const { rows } = await query(
+    `SELECT ha.*, ag.data_horario, s.nome_servico, p.nome as profissional, c.nome as cliente, a.nome as animal
+       FROM historico_atendimentos ha
+ INNER JOIN agendamentos ag ON ag.id_agendamento = ha.id_agendamento
+ INNER JOIN servicos s ON s.id_servico = ag.id_servico
+ INNER JOIN profissionais p ON p.id_profissional = ha.id_profissional
+ INNER JOIN clientes c ON c.id_cliente = ag.id_cliente
+ INNER JOIN animais a ON a.id_animal = ag.id_animal
+      ${whereClause}
+      ORDER BY ha.data_conclusao DESC`,
+    params
+  )
+
+  return rows
+}
+
+export async function registrarPresenca ({ idAgendamento, confirmado }) {
+  const agendamento = await buscarAgendamento(idAgendamento)
+  if (!agendamento) {
+    const error = new Error('Agendamento não encontrado')
+    error.status = 404
+    throw error
+  }
+
+  const status = confirmado ? AGENDAMENTO_STATUS.CONFIRMADO : AGENDAMENTO_STATUS.CANCELADO
+
+  const { rows } = await query(
+    `UPDATE agendamentos SET status = $1, atualizado_em = NOW()
+      WHERE id_agendamento = $2
+      RETURNING *`,
+    [status, idAgendamento]
+  )
+
+  return rows[0]
+}

--- a/backend/src/services/animaisService.js
+++ b/backend/src/services/animaisService.js
@@ -1,0 +1,24 @@
+import { query } from '../config/database.js'
+
+export async function cadastrarAnimal ({ idCliente, nome, especie, porte, idade, observacoes }) {
+  const { rows } = await query(
+    `INSERT INTO animais (id_cliente, nome, especie, porte, idade, observacoes)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+    [idCliente, nome, especie, porte, idade, observacoes]
+  )
+  return rows[0]
+}
+
+export async function listarAnimaisPorCliente (idCliente) {
+  const { rows } = await query(
+    `SELECT * FROM animais WHERE id_cliente = $1 ORDER BY nome`,
+    [idCliente]
+  )
+  return rows
+}
+
+export async function obterAnimal (idAnimal) {
+  const { rows } = await query('SELECT * FROM animais WHERE id_animal = $1', [idAnimal])
+  return rows[0]
+}

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -1,0 +1,134 @@
+import jwt from 'jsonwebtoken'
+import { comparePassword, hashPassword } from '../utils/password.js'
+import { obterClientePorEmail } from './clientesService.js'
+import { obterProfissionalPorEmail } from './profissionaisService.js'
+import { UserRole, AllowedRoles } from '../constants/roles.js'
+import { query } from '../config/database.js'
+
+function generateToken (payload) {
+  return jwt.sign(payload, process.env.JWT_SECRET, {
+    expiresIn: process.env.JWT_EXPIRES_IN || '1d'
+  })
+}
+
+export async function autenticarCliente ({ email, senha }) {
+  const cliente = await obterClientePorEmail(email)
+  if (!cliente) {
+    const error = new Error('Credenciais inválidas')
+    error.status = 401
+    throw error
+  }
+
+  const senhaValida = await comparePassword(senha, cliente.senha_hash)
+  if (!senhaValida) {
+    const error = new Error('Credenciais inválidas')
+    error.status = 401
+    throw error
+  }
+
+  const token = generateToken({
+    sub: cliente.id_cliente,
+    role: UserRole.CLIENTE,
+    email: cliente.email,
+    nome: cliente.nome
+  })
+
+  return {
+    token,
+    cliente: {
+      id_cliente: cliente.id_cliente,
+      nome: cliente.nome,
+      email: cliente.email
+    }
+  }
+}
+
+export async function autenticarProfissional ({ email, senha }) {
+  const profissional = await obterProfissionalPorEmail(email)
+  if (!profissional) {
+    const error = new Error('Credenciais inválidas')
+    error.status = 401
+    throw error
+  }
+
+  const senhaValida = await comparePassword(senha, profissional.senha_hash)
+  if (!senhaValida) {
+    const error = new Error('Credenciais inválidas')
+    error.status = 401
+    throw error
+  }
+
+  const token = generateToken({
+    sub: profissional.id_profissional,
+    role: UserRole.PROFISSIONAL,
+    email: profissional.email,
+    nome: profissional.nome
+  })
+
+  return {
+    token,
+    profissional: {
+      id_profissional: profissional.id_profissional,
+      nome: profissional.nome,
+      email: profissional.email,
+      telefone: profissional.telefone
+    }
+  }
+}
+
+export async function autenticarUsuario ({ email, senha, role }) {
+  if (!AllowedRoles.includes(role)) {
+    const error = new Error('Perfil inválido para autenticação')
+    error.status = 400
+    throw error
+  }
+
+  if (role === UserRole.CLIENTE) {
+    return autenticarCliente({ email, senha })
+  }
+
+  return autenticarProfissional({ email, senha })
+}
+
+export async function recuperarSenha ({ email }) {
+  const cliente = await obterClientePorEmail(email)
+  if (!cliente) {
+    const error = new Error('E-mail não encontrado')
+    error.status = 404
+    throw error
+  }
+
+  const token = generateToken({ sub: cliente.id_cliente, role: UserRole.CLIENTE, action: 'password_recovery' })
+
+  await query(
+    `INSERT INTO tokens_recuperacao (id_cliente, token, expiracao)
+     VALUES ($1, $2, NOW() + INTERVAL '1 hour')
+     ON CONFLICT (token) DO UPDATE SET expiracao = EXCLUDED.expiracao`,
+    [cliente.id_cliente, token]
+  )
+
+  return { token }
+}
+
+export async function redefinirSenha ({ token, novaSenha }) {
+  const { rows } = await query(
+    `SELECT tr.*, c.email FROM tokens_recuperacao tr
+      INNER JOIN clientes c ON c.id_cliente = tr.id_cliente
+     WHERE token = $1 AND expiracao > NOW()`,
+    [token]
+  )
+
+  const registro = rows[0]
+  if (!registro) {
+    const error = new Error('Token inválido ou expirado')
+    error.status = 400
+    throw error
+  }
+
+  const hash = await hashPassword(novaSenha)
+
+  await query('UPDATE clientes SET senha_hash = $1 WHERE id_cliente = $2', [hash, registro.id_cliente])
+  await query('DELETE FROM tokens_recuperacao WHERE id_token = $1', [registro.id_token])
+
+  return { success: true }
+}

--- a/backend/src/services/clientesService.js
+++ b/backend/src/services/clientesService.js
@@ -1,0 +1,32 @@
+import dayjs from 'dayjs'
+import { query } from '../config/database.js'
+import { hashPassword } from '../utils/password.js'
+
+export async function listarClientes () {
+  const { rows } = await query('SELECT id_cliente, nome, telefone, email, data_cadastro FROM clientes ORDER BY data_cadastro DESC')
+  return rows
+}
+
+export async function obterClientePorEmail (email) {
+  const { rows } = await query('SELECT * FROM clientes WHERE email = $1', [email])
+  return rows[0]
+}
+
+export async function criarCliente ({ nome, telefone, email, senha }) {
+  const existente = await obterClientePorEmail(email)
+  if (existente) {
+    const error = new Error('E-mail já cadastrado')
+    error.status = 400
+    throw error
+  }
+
+  const senhaHash = await hashPassword(senha)
+  const { rows } = await query(
+    `INSERT INTO clientes (nome, telefone, email, senha_hash, data_cadastro)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id_cliente, nome, telefone, email, data_cadastro`,
+    [nome, telefone, email, senhaHash, dayjs().toISOString()]
+  )
+
+  return rows[0]
+}

--- a/backend/src/services/profissionaisService.js
+++ b/backend/src/services/profissionaisService.js
@@ -1,0 +1,78 @@
+import { query } from '../config/database.js'
+import { hashPassword } from '../utils/password.js'
+
+export async function listarProfissionais () {
+  const { rows } = await query('SELECT id_profissional, nome, telefone, email, ativo FROM profissionais WHERE ativo = TRUE ORDER BY nome')
+  return rows
+}
+
+export async function obterProfissional (id) {
+  const { rows } = await query('SELECT * FROM profissionais WHERE id_profissional = $1', [id])
+  return rows[0]
+}
+
+export async function obterProfissionalPorEmail (email) {
+  const { rows } = await query('SELECT * FROM profissionais WHERE email = $1', [email])
+  return rows[0]
+}
+
+export async function criarProfissional ({ nome, telefone, email, senha, ativo = true }) {
+  const existente = await obterProfissionalPorEmail(email)
+  if (existente) {
+    const error = new Error('E-mail já cadastrado para profissional')
+    error.status = 400
+    throw error
+  }
+
+  const senhaHash = await hashPassword(senha)
+  const { rows } = await query(
+    `INSERT INTO profissionais (nome, telefone, email, senha_hash, ativo)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id_profissional, nome, telefone, email, ativo`,
+    [nome, telefone, email, senhaHash, ativo]
+  )
+
+  return rows[0]
+}
+
+export async function definirDisponibilidade ({ idProfissional, diaSemana, horaInicio, horaFim }) {
+  const { rows } = await query(
+    `INSERT INTO disponibilidades_profissionais (id_profissional, dia_semana, hora_inicio, hora_fim)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (id_profissional, dia_semana, hora_inicio)
+     DO UPDATE SET hora_fim = EXCLUDED.hora_fim
+     RETURNING *`,
+    [idProfissional, diaSemana, horaInicio, horaFim]
+  )
+  return rows[0]
+}
+
+export async function registrarIndisponibilidade ({ idProfissional, dataInicio, dataFim, motivo }) {
+  const { rows } = await query(
+    `INSERT INTO indisponibilidades_profissionais (id_profissional, data_inicio, data_fim, motivo)
+     VALUES ($1, $2, $3, $4)
+     RETURNING *`,
+    [idProfissional, dataInicio, dataFim, motivo]
+  )
+  return rows[0]
+}
+
+export async function listarDisponibilidades (idProfissional) {
+  const { rows } = await query(
+    `SELECT * FROM disponibilidades_profissionais
+      WHERE id_profissional = $1
+      ORDER BY dia_semana, hora_inicio`,
+    [idProfissional]
+  )
+  return rows
+}
+
+export async function listarIndisponibilidades (idProfissional) {
+  const { rows } = await query(
+    `SELECT * FROM indisponibilidades_profissionais
+      WHERE id_profissional = $1
+      ORDER BY data_inicio DESC`,
+    [idProfissional]
+  )
+  return rows
+}

--- a/backend/src/services/servicosService.js
+++ b/backend/src/services/servicosService.js
@@ -1,0 +1,41 @@
+import { query } from '../config/database.js'
+
+export async function listarServicos () {
+  const { rows } = await query('SELECT * FROM servicos ORDER BY nome_servico')
+  return rows
+}
+
+export async function criarServico ({ nomeServico, descricao, valor, tempoEstimado }) {
+  const tempo = Number(tempoEstimado) || 60
+  const { rows } = await query(
+    `INSERT INTO servicos (nome_servico, descricao, valor, tempo_estimado)
+     VALUES ($1, $2, $3, $4)
+     RETURNING *`,
+    [nomeServico, descricao, valor, tempo]
+  )
+  return rows[0]
+}
+
+export async function atualizarServico (idServico, { nomeServico, descricao, valor, tempoEstimado }) {
+  const tempo = Number(tempoEstimado) || 60
+  const { rows } = await query(
+    `UPDATE servicos
+        SET nome_servico = $1,
+            descricao = $2,
+            valor = $3,
+            tempo_estimado = $4
+      WHERE id_servico = $5
+    RETURNING *`,
+    [nomeServico, descricao, valor, tempo, idServico]
+  )
+  return rows[0]
+}
+
+export async function removerServico (idServico) {
+  await query('DELETE FROM servicos WHERE id_servico = $1', [idServico])
+}
+
+export async function obterServico (idServico) {
+  const { rows } = await query('SELECT * FROM servicos WHERE id_servico = $1', [idServico])
+  return rows[0]
+}

--- a/backend/src/utils/availability.js
+++ b/backend/src/utils/availability.js
@@ -1,0 +1,36 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc.js'
+import timezone from 'dayjs/plugin/timezone.js'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+export function generateTimeSlots ({ start, end, durationMinutes = 60 }) {
+  const slots = []
+  let pointer = dayjs(start)
+  const limit = dayjs(end)
+
+  while (pointer.add(durationMinutes, 'minute').diff(limit) <= 0) {
+    const slotStart = pointer
+    const slotEnd = pointer.add(durationMinutes, 'minute')
+    slots.push({
+      start: slotStart.toISOString(),
+      end: slotEnd.toISOString()
+    })
+    pointer = slotEnd
+  }
+
+  return slots
+}
+
+export function filterUnavailableSlots (slots, takenIntervals = []) {
+  return slots.filter(slot => {
+    return !takenIntervals.some(interval => {
+      const slotStart = dayjs(slot.start)
+      const slotEnd = dayjs(slot.end)
+      const takenStart = dayjs(interval.start)
+      const takenEnd = dayjs(interval.end)
+      return slotStart.isBefore(takenEnd) && slotEnd.isAfter(takenStart)
+    })
+  })
+}

--- a/backend/src/utils/notifications.js
+++ b/backend/src/utils/notifications.js
@@ -1,0 +1,12 @@
+export function sendNotification ({ type, recipient, message }) {
+  const timestamp = new Date().toISOString()
+  console.log(`[NOTIFICATION] [${timestamp}] [${type}] -> ${recipient}: ${message}`)
+}
+
+export const NotificationType = Object.freeze({
+  CONFIRMATION: 'CONFIRMATION',
+  REMINDER: 'REMINDER',
+  CANCELLATION: 'CANCELLATION',
+  RESCHEDULE: 'RESCHEDULE',
+  PASSWORD_RECOVERY: 'PASSWORD_RECOVERY'
+})

--- a/backend/src/utils/password.js
+++ b/backend/src/utils/password.js
@@ -1,0 +1,11 @@
+import bcrypt from 'bcryptjs'
+
+const SALT_ROUNDS = 10
+
+export async function hashPassword (password) {
+  return bcrypt.hash(password, SALT_ROUNDS)
+}
+
+export async function comparePassword (password, hash) {
+  return bcrypt.compare(password, hash)
+}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:4000/api

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,25 @@
+# Frontend - Sistema de Banho e Tosa
+
+## Scripts
+
+- `npm install` — instala dependências.
+- `npm start` — executa o projeto em modo desenvolvimento (porta 3000).
+- `npm run build` — gera build de produção.
+
+## Configuração
+
+Crie um arquivo `.env` na raiz do frontend com a variável `REACT_APP_API_URL` apontando para a API Express (por padrão `http://localhost:4000/api`).
+
+## Estrutura
+
+```
+src/
+  components/   # Componentes reutilizáveis (botões, cards, layout)
+  contexts/     # Contexto de autenticação
+  hooks/        # Hooks customizados
+  pages/        # Páginas principais (login, pets, agendamentos, dashboard)
+  routes/       # Rotas protegidas e públicas
+  services/     # Configuração do Axios
+```
+
+O projeto utiliza TailwindCSS para estilização e responsividade.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "pi-banho-e-tosa-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@headlessui/react": "^1.7.18",
+    "@heroicons/react": "^2.1.1",
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.3",
+    "clsx": "^1.2.1",
+    "dayjs": "^1.11.10"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.32",
+    "react-scripts": "5.0.1",
+    "tailwindcss": "^3.3.6"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Banho &amp; Tosa - Agenda</title>
+  </head>
+  <body class="bg-slate-50">
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { AuthProvider } from './contexts/AuthContext'
+import AppRoutes from './routes/AppRoutes'
+
+export default function App () {
+  return (
+    <AuthProvider>
+      <AppRoutes />
+    </AuthProvider>
+  )
+}

--- a/frontend/src/components/Button.jsx
+++ b/frontend/src/components/Button.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import clsx from 'clsx'
+
+const baseStyles = 'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-offset-2'
+
+const variants = {
+  primary: 'bg-primary-600 text-white hover:bg-primary-700 focus:ring-primary-500',
+  secondary: 'bg-white text-primary-600 border border-primary-200 hover:bg-primary-50 focus:ring-primary-200',
+  danger: 'bg-red-500 text-white hover:bg-red-600 focus:ring-red-400'
+}
+
+export default function Button ({ variant = 'primary', className, children, ...props }) {
+  return (
+    <button className={clsx(baseStyles, variants[variant], className)} {...props}>
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default function Card ({ title, actions, children, className }) {
+  return (
+    <div className={clsx('rounded-xl border border-slate-200 bg-white p-6 shadow-sm', className)}>
+      {(title || actions) && (
+        <div className="mb-4 flex items-center justify-between gap-4">
+          <h2 className="text-lg font-semibold text-slate-800">{title}</h2>
+          {actions && <div className="flex items-center gap-2">{actions}</div>}
+        </div>
+      )}
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/Input.jsx
+++ b/frontend/src/components/Input.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import clsx from 'clsx'
+
+export default function Input ({ label, error, className, ...props }) {
+  return (
+    <label className="flex flex-col gap-1 text-sm font-medium text-slate-600">
+      {label && <span>{label}</span>}
+      <input
+        className={clsx(
+          'rounded-md border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200',
+          error && 'border-red-300 focus:border-red-400 focus:ring-red-100',
+          className
+        )}
+        {...props}
+      />
+      {error && <span className="text-xs font-normal text-red-500">{error}</span>}
+    </label>
+  )
+}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { NavLink, useNavigate, Outlet } from 'react-router-dom'
+import { Bars3Icon } from '@heroicons/react/24/outline'
+import { Disclosure } from '@headlessui/react'
+import useAuth from '../hooks/useAuth'
+import Button from './Button'
+
+const navigation = [
+  { name: 'Agendamentos', to: '/agendamentos' },
+  { name: 'Agendar serviço', to: '/agendar' },
+  { name: 'Pets', to: '/pets' },
+  { name: 'Dashboard', to: '/dashboard' }
+]
+
+function NavItem ({ item }) {
+  return (
+    <NavLink
+      to={item.to}
+      className={({ isActive }) =>
+        `rounded-md px-3 py-2 text-sm font-medium transition ${
+          isActive ? 'bg-primary-100 text-primary-700' : 'text-slate-600 hover:bg-slate-100'
+        }`
+      }
+    >
+      {item.name}
+    </NavLink>
+  )
+}
+
+export default function Layout () {
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+
+  const handleLogout = () => {
+    logout()
+    navigate('/login')
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <Disclosure as="nav" className="border-b border-slate-200 bg-white shadow-sm">
+        {() => (
+          <>
+            <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+              <div className="flex h-16 items-center justify-between">
+                <div className="flex items-center gap-6">
+                  <div className="text-lg font-semibold text-primary-600">Banho &amp; Tosa</div>
+                  <div className="hidden gap-2 md:flex">
+                    {navigation.map(item => (
+                      <NavItem key={item.name} item={item} />
+                    ))}
+                  </div>
+                </div>
+                <div className="hidden items-center gap-4 md:flex">
+                  <span className="text-sm text-slate-600">Olá, {user?.nome}</span>
+                  <Button variant="secondary" onClick={handleLogout}>Sair</Button>
+                </div>
+                <div className="flex md:hidden">
+                  <Disclosure.Button className="inline-flex items-center justify-center rounded-md p-2 text-slate-500 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-primary-500">
+                    <Bars3Icon className="h-6 w-6" />
+                  </Disclosure.Button>
+                </div>
+              </div>
+            </div>
+            <Disclosure.Panel className="space-y-1 border-t border-slate-200 bg-white px-2 pb-3 pt-2 md:hidden">
+              {navigation.map(item => (
+                <NavLink
+                  key={item.name}
+                  to={item.to}
+                  className={({ isActive }) =>
+                    `block rounded-md px-3 py-2 text-base font-medium ${
+                      isActive ? 'bg-primary-100 text-primary-700' : 'text-slate-600 hover:bg-slate-100'
+                    }`
+                  }
+                >
+                  {item.name}
+                </NavLink>
+              ))}
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="block w-full rounded-md px-3 py-2 text-left text-base font-medium text-red-600 hover:bg-red-50"
+              >
+                Sair
+              </button>
+            </Disclosure.Panel>
+          </>
+        )}
+      </Disclosure>
+      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/components/PageHeader.jsx
+++ b/frontend/src/components/PageHeader.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function PageHeader ({ title, description, actions }) {
+  return (
+    <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">{title}</h1>
+        {description && <p className="mt-1 text-sm text-slate-500">{description}</p>}
+      </div>
+      {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
+    </div>
+  )
+}

--- a/frontend/src/components/StatsCard.jsx
+++ b/frontend/src/components/StatsCard.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import clsx from 'clsx'
+
+const colors = {
+  blue: 'bg-blue-50 text-blue-700',
+  green: 'bg-emerald-50 text-emerald-700',
+  violet: 'bg-violet-50 text-violet-700',
+  orange: 'bg-orange-50 text-orange-700',
+  red: 'bg-red-50 text-red-700'
+}
+
+export default function StatsCard ({ label, value, color = 'blue' }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <p className="text-sm font-medium text-slate-500">{label}</p>
+      <p className={clsx('mt-2 text-3xl font-semibold', colors[color] || colors.blue)}>{value}</p>
+    </div>
+  )
+}

--- a/frontend/src/components/Table.jsx
+++ b/frontend/src/components/Table.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+export default function Table ({ columns, data, emptyMessage = 'Nenhum registro encontrado.' }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200">
+      <table className="min-w-full divide-y divide-slate-200">
+        <thead className="bg-slate-50">
+          <tr>
+            {columns.map(column => (
+              <th
+                key={column.accessor}
+                className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500"
+              >
+                {column.Header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 bg-white text-sm">
+          {data.length === 0 && (
+            <tr>
+              <td colSpan={columns.length} className="px-4 py-6 text-center text-slate-500">
+                {emptyMessage}
+              </td>
+            </tr>
+          )}
+          {data.map((row, rowIndex) => (
+            <tr key={rowIndex} className="hover:bg-slate-50">
+              {columns.map(column => (
+                <td key={column.accessor} className="px-4 py-3 text-slate-600">
+                  {column.Cell ? column.Cell(row[column.accessor], row) : row[column.accessor]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,0 +1,86 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import api from '../services/api'
+
+const AuthContext = createContext()
+
+export function AuthProvider ({ children }) {
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem('auth_user')
+    return stored ? JSON.parse(stored) : null
+  })
+  const [token, setToken] = useState(() => localStorage.getItem('auth_token'))
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem('auth_token', token)
+    } else {
+      localStorage.removeItem('auth_token')
+    }
+  }, [token])
+
+  useEffect(() => {
+    if (user) {
+      localStorage.setItem('auth_user', JSON.stringify(user))
+    } else {
+      localStorage.removeItem('auth_user')
+    }
+  }, [user])
+
+  async function login ({ email, senha, role }) {
+    setLoading(true)
+    try {
+      const { data } = await api.post('/auth/login', { email, senha, role })
+      const payload = data.cliente
+        ? { role: 'cliente', ...data.cliente }
+        : data.profissional
+          ? { role: 'profissional', ...data.profissional }
+          : null
+
+      if (!payload) {
+        throw new Error('Resposta de autenticação inválida')
+      }
+      setUser(payload)
+      setToken(data.token)
+      return data
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function register ({ nome, telefone, email, senha }) {
+    setLoading(true)
+    try {
+      const { data } = await api.post('/clientes', { nome, telefone, email, senha })
+      return data
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function logout () {
+    setUser(null)
+    setToken(null)
+  }
+
+  const value = {
+    user,
+    token,
+    loading,
+    isAuthenticated: Boolean(user && token),
+    role: user?.role,
+    login,
+    register,
+    logout
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuthContext () {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuthContext deve ser usado dentro de AuthProvider')
+  }
+  return context
+}

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,0 +1,5 @@
+import { useAuthContext } from '../contexts/AuthContext'
+
+export default function useAuth () {
+  return useAuthContext()
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+}
+
+body {
+  @apply bg-slate-50 text-slate-700;
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './index.css'
+
+const container = document.getElementById('root')
+const root = createRoot(container)
+
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/frontend/src/pages/AppointmentsPage.jsx
+++ b/frontend/src/pages/AppointmentsPage.jsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react'
+import dayjs from 'dayjs'
+import Card from '../components/Card'
+import Button from '../components/Button'
+import PageHeader from '../components/PageHeader'
+import Table from '../components/Table'
+import useAuth from '../hooks/useAuth'
+import api from '../services/api'
+
+const columns = [
+  { Header: 'Data', accessor: 'data' },
+  { Header: 'Pet', accessor: 'animal' },
+  { Header: 'Serviço', accessor: 'servico' },
+  { Header: 'Profissional', accessor: 'profissional' },
+  { Header: 'Status', accessor: 'status' },
+  { Header: 'Ações', accessor: 'acoes' }
+]
+
+export default function AppointmentsPage () {
+  const { user } = useAuth()
+  const isCliente = user?.role === 'cliente'
+  const [agendamentos, setAgendamentos] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState('')
+
+  const fetchAgendamentos = async () => {
+    if (!isCliente) return
+    setLoading(true)
+    try {
+      const { data } = await api.get(`/agendamentos/clientes/${user.id_cliente}`)
+      setAgendamentos(
+        data.map(item => ({
+          ...item,
+          data: dayjs(item.data_horario).format('DD/MM/YYYY HH:mm'),
+          servico: item.nome_servico,
+          profissional: item.profissional,
+          animal: item.animal,
+          status: item.status
+        }))
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (isCliente && user?.id_cliente) {
+      fetchAgendamentos()
+    }
+  }, [user, isCliente])
+
+  const handleCancel = async agendamento => {
+    const motivo = window.prompt('Informe o motivo do cancelamento:')
+    if (!motivo) return
+    try {
+      await api.post(`/agendamentos/${agendamento.id_agendamento}/cancelar`, { motivo })
+      setMessage('Agendamento cancelado com sucesso.')
+      fetchAgendamentos()
+    } catch (err) {
+      setMessage(err.response?.data?.error || 'Não foi possível cancelar o agendamento.')
+    }
+  }
+
+  const handleReschedule = async agendamento => {
+    const novoHorario = window.prompt('Informe o novo horário (YYYY-MM-DDTHH:mm):', dayjs(agendamento.data_horario).toISOString().slice(0, 16))
+    if (!novoHorario) return
+    try {
+      await api.post(`/agendamentos/${agendamento.id_agendamento}/reagendar`, { novoHorario })
+      setMessage('Agendamento reagendado com sucesso.')
+      fetchAgendamentos()
+    } catch (err) {
+      setMessage(err.response?.data?.error || 'Não foi possível reagendar.')
+    }
+  }
+
+  if (!isCliente) {
+    return (
+      <div>
+        <PageHeader
+          title="Agendamentos"
+          description="Visualização de agendamentos está disponível somente para contas de clientes neste protótipo."
+        />
+        <Card>
+          <p className="text-sm text-slate-500">
+            Utilize uma conta de cliente para acompanhar, reagendar ou cancelar atendimentos.
+          </p>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Meus agendamentos"
+        description="Acompanhe o status dos agendamentos, reagende ou cancele quando necessário."
+      />
+      <Card>
+        {message && <p className="mb-4 text-sm text-slate-500">{message}</p>}
+        <Table
+          columns={columns}
+          data={agendamentos.map(item => ({
+            ...item,
+            acoes: (
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="secondary"
+                  onClick={() => handleReschedule(item)}
+                  disabled={item.status === 'cancelado' || item.status === 'concluido'}
+                >
+                  Reagendar
+                </Button>
+                <Button
+                  variant="danger"
+                  onClick={() => handleCancel(item)}
+                  disabled={item.status !== 'confirmado' && item.status !== 'pendente'}
+                >
+                  Cancelar
+                </Button>
+              </div>
+            )
+          }))}
+          emptyMessage={loading ? 'Carregando agendamentos...' : 'Nenhum agendamento encontrado.'}
+        />
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react'
+import PageHeader from '../components/PageHeader'
+import StatsCard from '../components/StatsCard'
+import Card from '../components/Card'
+import Table from '../components/Table'
+import api from '../services/api'
+import dayjs from 'dayjs'
+import useAuth from '../hooks/useAuth'
+
+const columns = [
+  { Header: 'Data', accessor: 'data' },
+  { Header: 'Serviço', accessor: 'servico' },
+  { Header: 'Profissional', accessor: 'profissional' },
+  { Header: 'Status', accessor: 'status' }
+]
+
+export default function DashboardPage () {
+  const { user } = useAuth()
+  const isCliente = user?.role === 'cliente'
+  const [stats, setStats] = useState(null)
+  const [recent, setRecent] = useState([])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const [statsRes, agendamentosRes] = await Promise.all([
+        api.get('/admin/dashboard'),
+        api.get(`/agendamentos/clientes/${user.id_cliente}`)
+      ])
+      setStats(statsRes.data)
+      setRecent(
+        agendamentosRes.data
+          .slice(0, 5)
+          .map(item => ({
+            ...item,
+            data: dayjs(item.data_horario).format('DD/MM/YYYY HH:mm'),
+            servico: item.nome_servico,
+            profissional: item.profissional,
+            status: item.status
+          }))
+      )
+    }
+    if (isCliente && user?.id_cliente) {
+      fetchData()
+    }
+  }, [user, isCliente])
+
+  if (!isCliente) {
+    return (
+      <div>
+        <PageHeader title="Painel" description="Estatísticas personalizadas disponíveis apenas para clientes." />
+        <Card>
+          <p className="text-sm text-slate-500">
+            Faça login como cliente para visualizar indicadores e agendamentos recentes.
+          </p>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <PageHeader title="Painel" description="Acompanhe os principais indicadores do sistema." />
+      {stats && (
+        <div className="grid gap-4 md:grid-cols-3 lg:grid-cols-6">
+          <StatsCard label="Clientes" value={stats.totalClientes} />
+          <StatsCard label="Pets" value={stats.totalAnimais} color="green" />
+          <StatsCard label="Serviços" value={stats.totalServicos} color="violet" />
+          <StatsCard label="Agendamentos" value={stats.totalAgendamentos} color="orange" />
+          <StatsCard label="Cancelamentos" value={stats.totalCancelamentos} color="red" />
+          <StatsCard label="Faltas" value={stats.totalFaltas} color="red" />
+        </div>
+      )}
+      <Card className="mt-8" title="Agendamentos recentes">
+        <Table columns={columns} data={recent} emptyMessage="Nenhum agendamento encontrado." />
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import Button from '../components/Button'
+import Input from '../components/Input'
+import useAuth from '../hooks/useAuth'
+import api from '../services/api'
+
+export default function LoginPage () {
+  const { login, loading } = useAuth()
+  const navigate = useNavigate()
+  const [form, setForm] = useState({ email: '', senha: '', role: 'cliente' })
+  const [error, setError] = useState('')
+  const [recoveryMessage, setRecoveryMessage] = useState('')
+
+  const handleChange = event => {
+    setForm(prev => ({ ...prev, [event.target.name]: event.target.value }))
+  }
+
+  const handleSubmit = async event => {
+    event.preventDefault()
+    setError('')
+    try {
+      await login(form)
+      navigate('/agendamentos')
+    } catch (err) {
+      setError(err.response?.data?.error || 'Não foi possível realizar login')
+    }
+  }
+
+  const handleRecovery = async () => {
+    if (!form.email) {
+      setRecoveryMessage('Informe um e-mail para recuperar a senha.')
+      return
+    }
+
+    try {
+      await api.post('/auth/recovery', { email: form.email })
+      setRecoveryMessage('Se o e-mail estiver cadastrado, um token foi enviado (verifique o console da API).')
+    } catch (err) {
+      setRecoveryMessage(err.response?.data?.error || 'Erro ao solicitar recuperação.')
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary-50 to-white px-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-xl">
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-bold text-slate-900">Acesse sua conta</h1>
+          <p className="mt-2 text-sm text-slate-500">Gerencie agendamentos de banho e tosa com facilidade.</p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            label="E-mail"
+            name="email"
+            type="email"
+            autoComplete="email"
+            value={form.email}
+            onChange={handleChange}
+            required
+          />
+          <Input
+            label="Senha"
+            name="senha"
+            type="password"
+            autoComplete="current-password"
+            value={form.senha}
+            onChange={handleChange}
+            required
+          />
+          <div>
+            <label htmlFor="role" className="mb-1 block text-sm font-medium text-slate-700">
+              Tipo de acesso
+            </label>
+            <select
+              id="role"
+              name="role"
+              value={form.role}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+            >
+              <option value="cliente">Cliente</option>
+              <option value="profissional">Profissional</option>
+            </select>
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Entrando...' : 'Entrar'}
+          </Button>
+        </form>
+        <button
+          type="button"
+          onClick={handleRecovery}
+          className="mt-4 text-sm text-primary-600 hover:text-primary-700"
+        >
+          Esqueci minha senha
+        </button>
+        {recoveryMessage && <p className="mt-2 text-xs text-slate-500">{recoveryMessage}</p>}
+        <p className="mt-6 text-center text-sm text-slate-500">
+          Ainda não possui conta?{' '}
+          <Link to="/cadastro" className="font-medium text-primary-600 hover:text-primary-700">
+            Cadastre-se
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/PetsPage.jsx
+++ b/frontend/src/pages/PetsPage.jsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState } from 'react'
+import Card from '../components/Card'
+import Button from '../components/Button'
+import Input from '../components/Input'
+import PageHeader from '../components/PageHeader'
+import Table from '../components/Table'
+import useAuth from '../hooks/useAuth'
+import api from '../services/api'
+
+const columns = [
+  { Header: 'Nome', accessor: 'nome' },
+  { Header: 'Espécie', accessor: 'especie' },
+  { Header: 'Porte', accessor: 'porte' },
+  { Header: 'Idade', accessor: 'idade' },
+  { Header: 'Observações', accessor: 'observacoes' }
+]
+
+export default function PetsPage () {
+  const { user } = useAuth()
+  const isCliente = user?.role === 'cliente'
+  const [pets, setPets] = useState([])
+  const [form, setForm] = useState({ nome: '', especie: '', porte: '', idade: '', observacoes: '' })
+  const [loading, setLoading] = useState(false)
+  const [feedback, setFeedback] = useState('')
+
+  const fetchPets = async () => {
+    if (!isCliente) return
+    const { data } = await api.get(`/animais/cliente/${user.id_cliente}`)
+    setPets(data)
+  }
+
+  useEffect(() => {
+    if (isCliente && user?.id_cliente) {
+      fetchPets()
+    }
+  }, [user, isCliente])
+
+  const handleChange = event => {
+    setForm(prev => ({ ...prev, [event.target.name]: event.target.value }))
+  }
+
+  const handleSubmit = async event => {
+    event.preventDefault()
+    setLoading(true)
+    setFeedback('')
+    try {
+      if (!isCliente) {
+        throw new Error('Somente clientes podem cadastrar pets')
+      }
+      await api.post('/animais', { ...form, idCliente: user.id_cliente, idade: Number(form.idade) || null })
+      setForm({ nome: '', especie: '', porte: '', idade: '', observacoes: '' })
+      setFeedback('Pet cadastrado com sucesso!')
+      fetchPets()
+    } catch (err) {
+      setFeedback(err.response?.data?.error || 'Não foi possível cadastrar o pet')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!isCliente) {
+    return (
+      <div>
+        <PageHeader title="Meus Pets" description="Cadastro disponível apenas para contas de clientes." />
+        <Card>
+          <p className="text-sm text-slate-500">Utilize uma conta de cliente para cadastrar e visualizar pets.</p>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <PageHeader title="Meus Pets" description="Cadastre e gerencie os animais vinculados à sua conta." />
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card className="lg:col-span-1" title="Cadastrar novo pet">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input label="Nome" name="nome" value={form.nome} onChange={handleChange} required />
+            <Input label="Espécie" name="especie" value={form.especie} onChange={handleChange} required />
+            <Input label="Porte" name="porte" value={form.porte} onChange={handleChange} />
+            <Input label="Idade" name="idade" type="number" value={form.idade} onChange={handleChange} />
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-600">
+              <span>Observações</span>
+              <textarea
+                name="observacoes"
+                value={form.observacoes}
+                onChange={handleChange}
+                className="min-h-[80px] rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              />
+            </label>
+            {feedback && <p className="text-sm text-slate-500">{feedback}</p>}
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? 'Salvando...' : 'Salvar pet'}
+            </Button>
+          </form>
+        </Card>
+        <Card className="lg:col-span-2" title="Lista de pets">
+          <Table columns={columns} data={pets} emptyMessage="Nenhum pet cadastrado." />
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import Button from '../components/Button'
+import Input from '../components/Input'
+import useAuth from '../hooks/useAuth'
+
+export default function RegisterPage () {
+  const { register, login, loading } = useAuth()
+  const navigate = useNavigate()
+  const [form, setForm] = useState({ nome: '', telefone: '', email: '', senha: '' })
+  const [error, setError] = useState('')
+
+  const handleChange = event => {
+    setForm(prev => ({ ...prev, [event.target.name]: event.target.value }))
+  }
+
+  const handleSubmit = async event => {
+    event.preventDefault()
+    setError('')
+    try {
+      await register(form)
+      await login({ email: form.email, senha: form.senha })
+      navigate('/agendamentos')
+    } catch (err) {
+      setError(err.response?.data?.error || 'Não foi possível realizar o cadastro')
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary-50 to-white px-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-xl">
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-bold text-slate-900">Crie sua conta</h1>
+          <p className="mt-2 text-sm text-slate-500">Cadastre seus pets e agende serviços personalizados.</p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input label="Nome completo" name="nome" value={form.nome} onChange={handleChange} required />
+          <Input label="Telefone" name="telefone" value={form.telefone} onChange={handleChange} required />
+          <Input label="E-mail" name="email" type="email" value={form.email} onChange={handleChange} required />
+          <Input label="Senha" name="senha" type="password" value={form.senha} onChange={handleChange} required />
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Cadastrando...' : 'Cadastrar'}
+          </Button>
+        </form>
+        <p className="mt-6 text-center text-sm text-slate-500">
+          Já possui conta?{' '}
+          <Link to="/login" className="font-medium text-primary-600 hover:text-primary-700">
+            Entrar
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/SchedulePage.jsx
+++ b/frontend/src/pages/SchedulePage.jsx
@@ -1,0 +1,232 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import Card from '../components/Card'
+import Button from '../components/Button'
+import Input from '../components/Input'
+import PageHeader from '../components/PageHeader'
+import useAuth from '../hooks/useAuth'
+import api from '../services/api'
+import dayjs from 'dayjs'
+
+export default function SchedulePage () {
+  const { user } = useAuth()
+  const isCliente = user?.role === 'cliente'
+  const [pets, setPets] = useState([])
+  const [servicos, setServicos] = useState([])
+  const [profissionais, setProfissionais] = useState([])
+  const [slots, setSlots] = useState([])
+  const [form, setForm] = useState({
+    idAnimal: '',
+    idServico: '',
+    idProfissional: '',
+    data: dayjs().format('YYYY-MM-DD'),
+    horario: ''
+  })
+  const [observacoes, setObservacoes] = useState('')
+  const [feedback, setFeedback] = useState('')
+  const [loadingSlots, setLoadingSlots] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    const fetchInitialData = async () => {
+      const [petsRes, servicosRes, profRes] = await Promise.all([
+        api.get(`/animais/cliente/${user.id_cliente}`),
+        api.get('/servicos'),
+        api.get('/profissionais')
+      ])
+      setPets(petsRes.data)
+      setServicos(servicosRes.data)
+      setProfissionais(profRes.data)
+      if (petsRes.data[0]) {
+        setForm(prev => ({ ...prev, idAnimal: petsRes.data[0].id_animal }))
+      }
+      if (servicosRes.data[0]) {
+        setForm(prev => ({ ...prev, idServico: servicosRes.data[0].id_servico }))
+      }
+      if (profRes.data[0]) {
+        setForm(prev => ({ ...prev, idProfissional: profRes.data[0].id_profissional }))
+      }
+    }
+    if (isCliente && user?.id_cliente) {
+      fetchInitialData()
+    }
+  }, [user, isCliente])
+
+  const canLoadSlots = useMemo(() => {
+    return form.idServico && form.idProfissional && form.data
+  }, [form.idServico, form.idProfissional, form.data])
+
+  useEffect(() => {
+    const fetchSlots = async () => {
+      if (!canLoadSlots) return
+      setLoadingSlots(true)
+      try {
+        const params = new URLSearchParams({
+          idProfissional: form.idProfissional,
+          data: form.data,
+          idServico: form.idServico
+        })
+        const { data } = await api.get(`/agendamentos/disponiveis?${params.toString()}`)
+        setSlots(data)
+      } catch (error) {
+        console.error(error)
+      } finally {
+        setLoadingSlots(false)
+      }
+    }
+    fetchSlots()
+  }, [form.idProfissional, form.idServico, form.data, canLoadSlots])
+
+  const handleChange = event => {
+    const { name, value } = event.target
+    setForm(prev => {
+      const updated = { ...prev, [name]: value }
+      if (name === 'data') {
+        updated.horario = ''
+      }
+      return updated
+    })
+  }
+
+  const handleSubmit = async event => {
+    event.preventDefault()
+    setFeedback('')
+    setSaving(true)
+    try {
+      if (!isCliente) {
+        throw new Error('Somente clientes podem agendar serviços')
+      }
+      await api.post('/agendamentos', {
+        idCliente: user.id_cliente,
+        idAnimal: form.idAnimal,
+        idServico: form.idServico,
+        idProfissional: form.idProfissional,
+        dataHorario: form.horario,
+        observacoes
+      })
+      setFeedback('Agendamento criado com sucesso!')
+      setObservacoes('')
+    } catch (err) {
+      setFeedback(err.response?.data?.error || 'Não foi possível criar o agendamento')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!isCliente) {
+    return (
+      <div>
+        <PageHeader
+          title="Agendar serviço"
+          description="O agendamento está disponível somente para clientes autenticados."
+        />
+        <Card>
+          <p className="text-sm text-slate-500">
+            Utilize uma conta de cliente para selecionar pets e horários disponíveis.
+          </p>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Agendar serviço"
+        description="Escolha o pet, serviço, profissional e horário disponível para confirmar o atendimento."
+      />
+      <Card>
+        <form className="grid gap-6 md:grid-cols-2" onSubmit={handleSubmit}>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-600">
+            <span>Pet</span>
+            <select
+              name="idAnimal"
+              value={form.idAnimal}
+              onChange={handleChange}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+            >
+              <option value="">Selecione</option>
+              {pets.map(pet => (
+                <option key={pet.id_animal} value={pet.id_animal}>
+                  {pet.nome}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-600">
+            <span>Serviço</span>
+            <select
+              name="idServico"
+              value={form.idServico}
+              onChange={handleChange}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+            >
+              <option value="">Selecione</option>
+              {servicos.map(servico => (
+                <option key={servico.id_servico} value={servico.id_servico}>
+                  {servico.nome_servico}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium text-slate-600">
+            <span>Profissional</span>
+            <select
+              name="idProfissional"
+              value={form.idProfissional}
+              onChange={handleChange}
+              className="rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+            >
+              <option value="">Selecione</option>
+              {profissionais.map(profissional => (
+                <option key={profissional.id_profissional} value={profissional.id_profissional}>
+                  {profissional.nome}
+                </option>
+              ))}
+            </select>
+          </label>
+          <Input label="Data" type="date" name="data" value={form.data} onChange={handleChange} min={dayjs().format('YYYY-MM-DD')} />
+
+          <div className="md:col-span-2">
+            <span className="block text-sm font-medium text-slate-600">Horário disponível</span>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {loadingSlots && <p className="text-sm text-slate-500">Carregando horários...</p>}
+              {!loadingSlots && slots.length === 0 && (
+                <p className="text-sm text-slate-500">Nenhum horário disponível para os filtros selecionados.</p>
+              )}
+              {slots.map(slot => (
+                <button
+                  key={slot.start}
+                  type="button"
+                  onClick={() => setForm(prev => ({ ...prev, horario: slot.start }))}
+                  className={`rounded-md border px-3 py-2 text-sm ${
+                    form.horario === slot.start
+                      ? 'border-primary-400 bg-primary-100 text-primary-700'
+                      : 'border-slate-200 bg-white text-slate-600 hover:border-primary-200'
+                  }`}
+                >
+                  {dayjs(slot.start).format('DD/MM/YYYY HH:mm')}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <label className="md:col-span-2 flex flex-col gap-1 text-sm font-medium text-slate-600">
+            <span>Observações</span>
+            <textarea
+              value={observacoes}
+              onChange={event => setObservacoes(event.target.value)}
+              className="min-h-[100px] rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+            />
+          </label>
+
+          <div className="md:col-span-2 flex items-center justify-between gap-4">
+            {feedback && <p className="text-sm text-slate-500">{feedback}</p>}
+            <Button type="submit" disabled={!form.horario || saving}>
+              {saving ? 'Agendando...' : 'Confirmar agendamento'}
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { Navigate, Route, Routes } from 'react-router-dom'
+import useAuth from '../hooks/useAuth'
+import Layout from '../components/Layout'
+import LoginPage from '../pages/LoginPage'
+import RegisterPage from '../pages/RegisterPage'
+import PetsPage from '../pages/PetsPage'
+import SchedulePage from '../pages/SchedulePage'
+import AppointmentsPage from '../pages/AppointmentsPage'
+import DashboardPage from '../pages/DashboardPage'
+
+function ProtectedRoute ({ children }) {
+  const { isAuthenticated } = useAuth()
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />
+  }
+  return children
+}
+
+function PublicOnlyRoute ({ children }) {
+  const { isAuthenticated } = useAuth()
+  if (isAuthenticated) {
+    return <Navigate to="/agendamentos" replace />
+  }
+  return children
+}
+
+export default function AppRoutes () {
+  return (
+    <Routes>
+      <Route
+        path="/login"
+        element={(
+          <PublicOnlyRoute>
+            <LoginPage />
+          </PublicOnlyRoute>
+        )}
+      />
+      <Route
+        path="/cadastro"
+        element={(
+          <PublicOnlyRoute>
+            <RegisterPage />
+          </PublicOnlyRoute>
+        )}
+      />
+      <Route
+        path="/"
+        element={(
+          <ProtectedRoute>
+            <Layout />
+          </ProtectedRoute>
+        )}
+      >
+        <Route index element={<Navigate to="/agendamentos" replace />} />
+        <Route path="agendamentos" element={<AppointmentsPage />} />
+        <Route path="agendar" element={<SchedulePage />} />
+        <Route path="pets" element={<PetsPage />} />
+        <Route path="dashboard" element={<DashboardPage />} />
+      </Route>
+      <Route path="*" element={<Navigate to="/agendamentos" replace />} />
+    </Routes>
+  )
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,15 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: process.env.REACT_APP_API_URL || 'http://localhost:4000/api'
+})
+
+api.interceptors.request.use(config => {
+  const token = localStorage.getItem('auth_token')
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+export default api

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,23 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#f2f7ff',
+          100: '#e0ecff',
+          200: '#bcd5ff',
+          300: '#8ab8ff',
+          400: '#5592ff',
+          500: '#2f6dff',
+          600: '#1d4fe6',
+          700: '#163bb4',
+          800: '#122c84',
+          900: '#101f5c'
+        }
+      }
+    }
+  },
+  plugins: []
+}


### PR DESCRIPTION
## Summary
- introduce shared role constants and extend authentication to issue JWTs for clientes e profissionais
- allow cadastro de profissionais com senha protegida e expor endpoint dedicado
- ajustar frontend para seleção de perfil no login e proteger páginas exclusivas de clientes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc677f69b48327a40fadd5f47fb062