### PR TITLE
Add landing page and chatbot support

### DIFF
--- a/backend/src/controllers/chatbotController.js
+++ b/backend/src/controllers/chatbotController.js
@@ -1,0 +1,12 @@
+import { responderMensagem } from '../services/chatbotService.js'
+
+export async function enviarMensagem (req, res) {
+  const { message } = req.body
+
+  if (message !== undefined && typeof message !== 'string') {
+    return res.status(400).json({ error: 'Mensagem deve ser um texto.' })
+  }
+
+  const resposta = await responderMensagem({ message })
+  res.json(resposta)
+}

--- a/backend/src/routes/chatbot.routes.js
+++ b/backend/src/routes/chatbot.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express'
+import { enviarMensagem } from '../controllers/chatbotController.js'
+
+const router = Router()
+
+router.post('/', enviarMensagem)
+
+export default router

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -7,6 +7,7 @@ import agendamentosRoutes from './agendamentos.routes.js'
 import profissionaisRoutes from './profissionais.routes.js'
 import servicosRoutes from './servicos.routes.js'
 import adminRoutes from './admin.routes.js'
+import chatbotRoutes from './chatbot.routes.js'
 
 const router = Router()
 
@@ -17,5 +18,6 @@ router.use('/agendamentos', agendamentosRoutes)
 router.use('/profissionais', profissionaisRoutes)
 router.use('/servicos', servicosRoutes)
 router.use('/admin', adminRoutes)
+router.use('/chatbot', chatbotRoutes)
 
 export default router

--- a/backend/src/services/chatbotService.js
+++ b/backend/src/services/chatbotService.js
@@ -1,0 +1,157 @@
+import { listarServicos } from './servicosService.js'
+import { listarProfissionais } from './profissionaisService.js'
+
+const BASE_SUGGESTIONS = Object.freeze([
+  'Quais serviços vocês oferecem?',
+  'Quais são os horários de funcionamento?',
+  'Como faço para agendar?',
+  'Posso cancelar um agendamento?'
+])
+
+const BUSINESS_INFO = {
+  hours: 'Funcionamos de segunda a sábado, das 9h às 18h. Aos domingos atendemos apenas com agendamento prévio.',
+  address: 'Rua dos Pets, 123 - Centro, São Paulo/SP',
+  phone: '(11) 99999-0000',
+  whatsapp: '(11) 98888-0000'
+}
+
+function normalize (text = '') {
+  return text
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+}
+
+function includesAny (text, keywords) {
+  return keywords.some(keyword => text.includes(keyword))
+}
+
+function formatCurrency (value) {
+  if (value === null || value === undefined) return 'sob consulta'
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(Number(value))
+}
+
+function buildSuggestions (...extra) {
+  const set = new Set(BASE_SUGGESTIONS)
+  extra.forEach(item => {
+    if (item) set.add(item)
+  })
+  return Array.from(set)
+}
+
+export async function responderMensagem ({ message }) {
+  const suggestions = buildSuggestions()
+
+  if (!message || !message.trim()) {
+    return {
+      reply: 'Olá! Sou a assistente virtual da Banho & Tosa. Posso te ajudar a conhecer nossos serviços, horários e como agendar um atendimento.',
+      suggestions
+    }
+  }
+
+  const normalized = normalize(message)
+
+  if (includesAny(normalized, ['servic', 'banho', 'tosa', 'pacote'])) {
+    const servicos = await listarServicos()
+    if (!servicos.length) {
+      return {
+        reply: 'Estamos atualizando nossos serviços no momento. Tente novamente em instantes ou fale direto com a equipe pelo telefone.',
+        suggestions: buildSuggestions('Como faço para agendar?', 'Qual o telefone de contato?')
+      }
+    }
+
+    const lista = servicos
+      .map(servico => `• ${servico.nome_servico} (${formatCurrency(servico.valor)})`)
+      .join('\n')
+
+    return {
+      reply: `Esses são alguns dos nossos serviços atuais:\n${lista}\nVocê pode conferir mais detalhes e agendar direto pelo painel ou comigo. É só dizer!`,
+      suggestions: buildSuggestions('Como faço para agendar?', 'Quais são os horários de funcionamento?')
+    }
+  }
+
+  if (includesAny(normalized, ['horario', 'funcionamento', 'abrem', 'fecham', 'aberto'])) {
+    return {
+      reply: `${BUSINESS_INFO.hours}\nSe precisar de um horário especial, posso verificar com nossa equipe para você.`,
+      suggestions: buildSuggestions('Como faço para agendar?', 'Quais serviços vocês oferecem?')
+    }
+  }
+
+  if (includesAny(normalized, ['agend', 'marcar', 'horario disponivel', 'agendar'])) {
+    return {
+      reply: 'Para agendar, faça login ou crie sua conta, cadastre o pet e escolha o serviço. Você também pode ir na aba “Agendar serviço” e selecionar o melhor horário disponível.',
+      suggestions: buildSuggestions('Quais serviços vocês oferecem?', 'Posso cancelar um agendamento?')
+    }
+  }
+
+  if (includesAny(normalized, ['cancel', 'desmarc'])) {
+    return {
+      reply: 'Você pode cancelar um agendamento com até 2 horas de antecedência direto pelo painel em “Agendamentos”. Se precisar de ajuda, me avise que encaminho para nossa equipe.',
+      suggestions: buildSuggestions('Quais serviços vocês oferecem?', 'Como faço para agendar?')
+    }
+  }
+
+  if (includesAny(normalized, ['profission', 'especialista', 'groomer'])) {
+    const profissionais = await listarProfissionais()
+    if (!profissionais.length) {
+      return {
+        reply: 'Nossa equipe está sendo atualizada neste momento. Em breve teremos novos profissionais disponíveis!',
+        suggestions
+      }
+    }
+
+    const lista = profissionais
+      .map(pro => `• ${pro.nome} - contato: ${pro.telefone || 'sem telefone'} / ${pro.email}`)
+      .join('\n')
+
+    return {
+      reply: `Temos uma equipe especializada pronta para atender:\n${lista}\nAo agendar um serviço você pode escolher o profissional disponível.`,
+      suggestions: buildSuggestions('Como faço para agendar?', 'Quais são os horários de funcionamento?')
+    }
+  }
+
+  if (includesAny(normalized, ['preco', 'valor', 'quanto', 'investimento'])) {
+    const servicos = await listarServicos()
+    if (!servicos.length) {
+      return {
+        reply: 'Os valores variam conforme o porte do pet e o tipo de serviço. Entre em contato pelo WhatsApp para receber um orçamento personalizado.',
+        suggestions: buildSuggestions('Qual o WhatsApp de contato?', 'Quais serviços vocês oferecem?')
+      }
+    }
+
+    const lista = servicos
+      .map(servico => `• ${servico.nome_servico}: ${formatCurrency(servico.valor)}`)
+      .join('\n')
+
+    return {
+      reply: `Os valores dos principais serviços são:\n${lista}\nNo momento do agendamento informamos o valor final conforme o perfil do pet.`,
+      suggestions: buildSuggestions('Como faço para agendar?', 'Posso cancelar um agendamento?')
+    }
+  }
+
+  if (includesAny(normalized, ['whats', 'zap', 'telefone', 'contato', 'falar'])) {
+    return {
+      reply: `Você pode falar com nossa equipe pelos canais a seguir:\n• Telefone: ${BUSINESS_INFO.phone}\n• WhatsApp: ${BUSINESS_INFO.whatsapp}\n• Endereço: ${BUSINESS_INFO.address}`,
+      suggestions: buildSuggestions('Quais serviços vocês oferecem?', 'Como faço para agendar?')
+    }
+  }
+
+  if (includesAny(normalized, ['enderec', 'local', 'onde', 'ficam'])) {
+    return {
+      reply: `Estamos localizados em ${BUSINESS_INFO.address}. Há estacionamento conveniado ao lado da loja.`,
+      suggestions: buildSuggestions('Quais são os horários de funcionamento?', 'Como faço para agendar?')
+    }
+  }
+
+  if (includesAny(normalized, ['obrigad', 'valeu', 'perfeito'])) {
+    return {
+      reply: 'Eu que agradeço! Se precisar de mais alguma coisa é só me chamar. 🐾',
+      suggestions
+    }
+  }
+
+  return {
+    reply: 'Ainda não tenho informações sobre isso, mas posso te ajudar com nossos serviços, horários, valores ou contato. Qual dessas opções você gostaria de saber?',
+    suggestions
+  }
+}

--- a/frontend/src/components/ChatbotWidget.jsx
+++ b/frontend/src/components/ChatbotWidget.jsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { ChatBubbleOvalLeftEllipsisIcon, PaperAirplaneIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import api from '../services/api'
+
+const INITIAL_MESSAGE = 'Olá! Eu sou a Luma, assistente virtual da Banho & Tosa. Como posso te ajudar hoje?'
+const DEFAULT_SUGGESTIONS = [
+  'Quais serviços vocês oferecem?',
+  'Quais são os horários de funcionamento?',
+  'Como faço para agendar?',
+  'Posso cancelar um agendamento?'
+]
+
+export default function ChatbotWidget ({ initialOpen = false }) {
+  const [isOpen, setIsOpen] = useState(initialOpen)
+  const [messages, setMessages] = useState([{ sender: 'bot', text: INITIAL_MESSAGE }])
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [suggestions, setSuggestions] = useState(DEFAULT_SUGGESTIONS)
+  const endRef = useRef(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      endRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [messages, isOpen])
+
+  const sendMessage = async content => {
+    if (loading) return
+    const trimmed = content.trim()
+    if (!trimmed) return
+
+    setMessages(prev => [...prev, { sender: 'user', text: trimmed }])
+    setInput('')
+    setLoading(true)
+
+    try {
+      const { data } = await api.post('/chatbot', { message: trimmed })
+      setMessages(prev => [...prev, { sender: 'bot', text: data.reply }])
+      if (Array.isArray(data.suggestions) && data.suggestions.length > 0) {
+        setSuggestions(data.suggestions)
+      }
+    } catch (error) {
+      console.error(error)
+      setMessages(prev => [
+        ...prev,
+        { sender: 'bot', text: 'Desculpe, não consegui falar com nossa central agora. Tente novamente em instantes.' }
+      ])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSubmit = event => {
+    event.preventDefault()
+    sendMessage(input)
+  }
+
+  const handleSuggestion = suggestion => {
+    sendMessage(suggestion)
+  }
+
+  const renderMessage = message => {
+    const lines = message.text.split('\n')
+    return lines.map((line, index) => (
+      <React.Fragment key={`${index}-${line}`}>
+        {line}
+        {index < lines.length - 1 && <br />}
+      </React.Fragment>
+    ))
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      {isOpen ? (
+        <div className="flex w-80 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl">
+          <div className="flex items-center justify-between bg-primary-600 px-4 py-3 text-white">
+            <div>
+              <p className="text-sm font-semibold">Assistente Banho &amp; Tosa</p>
+              <p className="text-xs opacity-90">Tempo médio de resposta em segundos</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsOpen(false)}
+              className="rounded-full p-1 transition hover:bg-primary-500"
+              aria-label="Fechar chat"
+            >
+              <XMarkIcon className="h-5 w-5" />
+            </button>
+          </div>
+          <div className="flex flex-1 flex-col gap-3 overflow-y-auto bg-slate-50 px-4 py-3">
+            {messages.map((message, index) => (
+              <div
+                key={index}
+                className={`max-w-[90%] rounded-2xl px-3 py-2 text-sm leading-relaxed shadow-sm ${
+                  message.sender === 'user'
+                    ? 'self-end rounded-br-none bg-primary-600 text-white'
+                    : 'self-start rounded-bl-none bg-white text-slate-700'
+                }`}
+              >
+                {renderMessage(message)}
+              </div>
+            ))}
+            {loading && (
+              <div className="self-start rounded-2xl rounded-bl-none bg-white px-3 py-2 text-sm text-slate-500 shadow-sm">
+                Digitando...
+              </div>
+            )}
+            <div ref={endRef} />
+          </div>
+          {suggestions.length > 0 && (
+            <div className="flex flex-wrap gap-2 border-t border-slate-200 px-4 py-2">
+              {suggestions.slice(0, 3).map(suggestion => (
+                <button
+                  key={suggestion}
+                  type="button"
+                  onClick={() => handleSuggestion(suggestion)}
+                  className="rounded-full border border-primary-200 px-3 py-1 text-xs text-primary-600 transition hover:bg-primary-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={loading}
+                >
+                  {suggestion}
+                </button>
+              ))}
+            </div>
+          )}
+          <form onSubmit={handleSubmit} className="flex items-center gap-2 border-t border-slate-200 bg-white px-4 py-3">
+            <input
+              type="text"
+              value={input}
+              onChange={event => setInput(event.target.value)}
+              placeholder="Digite sua mensagem"
+              className="flex-1 rounded-full border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              disabled={loading}
+            />
+            <button
+              type="submit"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary-600 text-white transition hover:bg-primary-700 disabled:opacity-60"
+              disabled={loading}
+              aria-label="Enviar mensagem"
+            >
+              <PaperAirplaneIcon className="h-4 w-4" />
+            </button>
+          </form>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          className="flex items-center gap-3 rounded-full bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-lg transition hover:bg-primary-700"
+        >
+          <ChatBubbleOvalLeftEllipsisIcon className="h-5 w-5" />
+          Falar com a Luma
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -4,17 +4,18 @@ import { Bars3Icon } from '@heroicons/react/24/outline'
 import { Disclosure } from '@headlessui/react'
 import useAuth from '../hooks/useAuth'
 import Button from './Button'
+import ChatbotWidget from './ChatbotWidget'
 
 const clientNavigation = [
-  { name: 'Agendamentos', to: '/agendamentos' },
-  { name: 'Agendar serviço', to: '/agendar' },
-  { name: 'Pets', to: '/pets' },
-  { name: 'Dashboard', to: '/dashboard' }
+  { name: 'Agendamentos', to: '/app/agendamentos' },
+  { name: 'Agendar serviço', to: '/app/agendar' },
+  { name: 'Pets', to: '/app/pets' },
+  { name: 'Dashboard', to: '/app/dashboard' }
 ]
 
 const professionalNavigation = [
-  { name: 'Gestão', to: '/gestao' },
-  { name: 'Dashboard', to: '/dashboard' }
+  { name: 'Gestão', to: '/app/gestao' },
+  { name: 'Dashboard', to: '/app/dashboard' }
 ]
 
 function NavItem ({ item }) {
@@ -97,6 +98,7 @@ export default function Layout () {
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <Outlet />
       </main>
+      <ChatbotWidget />
     </div>
   )
 }

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,0 +1,221 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { CalendarDaysIcon, ChatBubbleLeftRightIcon, ShieldCheckIcon, SparklesIcon } from '@heroicons/react/24/outline'
+import ChatbotWidget from '../components/ChatbotWidget'
+import useAuth from '../hooks/useAuth'
+
+const features = [
+  {
+    name: 'Agenda inteligente',
+    description: 'Escolha serviços, profissionais e horários disponíveis em poucos cliques, com confirmação automática.',
+    icon: CalendarDaysIcon
+  },
+  {
+    name: 'Atendimento personalizado',
+    description: 'Cadastro completo dos pets, histórico de cuidados e observações para experiências mais seguras.',
+    icon: ShieldCheckIcon
+  },
+  {
+    name: 'Chatbot sempre online',
+    description: 'Receba suporte imediato com a Luma para dúvidas sobre serviços, horários e agendamentos.',
+    icon: ChatBubbleLeftRightIcon
+  }
+]
+
+const steps = [
+  {
+    title: '1. Crie sua conta',
+    description: 'Cadastre seus dados e dos seus pets em minutos.'
+  },
+  {
+    title: '2. Escolha o serviço',
+    description: 'Compare opções de banho, tosa, hidratação e cuidados especiais.'
+  },
+  {
+    title: '3. Confirme o melhor horário',
+    description: 'Veja horários livres em tempo real e receba notificações automáticas.'
+  }
+]
+
+const faqs = [
+  {
+    question: 'Quais serviços estão disponíveis?',
+    answer: 'Oferecemos banho, tosa higiênica, tosa completa, hidratação, desembolo e pacotes especiais para diferentes portes. Confira detalhes e valores direto no painel ou converse com a Luma.'
+  },
+  {
+    question: 'Posso reagendar ou cancelar?',
+    answer: 'Sim. Pelo painel de agendamentos você pode reagendar ou cancelar com até 2 horas de antecedência. Também enviamos confirmações e lembretes automáticos.'
+  },
+  {
+    question: 'O atendimento presencial é onde?',
+    answer: 'Nossa loja fica na Rua dos Pets, 123, Centro de São Paulo/SP. Temos estacionamento conveniado ao lado da unidade.'
+  }
+]
+
+export default function LandingPage () {
+  const { isAuthenticated, user } = useAuth()
+  const defaultPath = user?.role === 'profissional' ? '/app/gestao' : '/app/agendamentos'
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-primary-50 via-white to-white">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(47,109,255,0.12),_transparent_55%)]" aria-hidden="true" />
+
+      <header className="mx-auto flex w-full max-w-7xl items-center justify-between px-6 py-6">
+        <Link to="/" className="text-lg font-semibold text-primary-700">
+          Banho &amp; Tosa
+        </Link>
+        <div className="flex items-center gap-3 text-sm font-medium text-slate-600">
+          {!isAuthenticated && (
+            <Link to="/login" className="rounded-full px-4 py-2 transition hover:bg-primary-100 hover:text-primary-700">
+              Entrar
+            </Link>
+          )}
+          <Link to={isAuthenticated ? defaultPath : '/cadastro'} className="rounded-full bg-primary-600 px-4 py-2 text-white transition hover:bg-primary-700">
+            {isAuthenticated ? 'Ir para o painel' : 'Criar conta'}
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-24 px-6 pb-24">
+        <section className="grid items-center gap-12 lg:grid-cols-2">
+          <div className="space-y-6">
+            <span className="inline-flex items-center rounded-full bg-primary-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary-700">
+              Banho &amp; tosa com experiência premium
+            </span>
+            <h1 className="text-4xl font-bold text-slate-900 sm:text-5xl">
+              Agendamentos descomplicados e cuidados que seu pet merece
+            </h1>
+            <p className="text-lg text-slate-600">
+              Organize banhos, tosas e tratamentos especiais em um painel intuitivo. Nossa equipe especialista cuida do seu pet e nossa assistente virtual acompanha cada etapa.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link to={isAuthenticated ? defaultPath : '/cadastro'} className="inline-flex items-center rounded-full bg-primary-600 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-primary-700">
+                Começar agora
+              </Link>
+              <Link to={isAuthenticated ? defaultPath : '/login'} className="inline-flex items-center rounded-full border border-primary-200 px-6 py-3 text-sm font-semibold text-primary-600 transition hover:bg-primary-50">
+                Ver agendamentos
+              </Link>
+            </div>
+            <dl className="grid gap-6 sm:grid-cols-3">
+              <div>
+                <dt className="text-sm text-slate-500">Tempo médio de agendamento</dt>
+                <dd className="text-2xl font-semibold text-slate-900">3 minutos</dd>
+              </div>
+              <div>
+                <dt className="text-sm text-slate-500">Profissionais certificados</dt>
+                <dd className="text-2xl font-semibold text-slate-900">+15 groomers</dd>
+              </div>
+              <div>
+                <dt className="text-sm text-slate-500">Avaliação dos clientes</dt>
+                <dd className="text-2xl font-semibold text-slate-900">4,9/5</dd>
+              </div>
+            </dl>
+          </div>
+          <div className="relative">
+            <div className="absolute -inset-8 -z-10 rounded-3xl bg-primary-100 opacity-60 blur-3xl" aria-hidden="true" />
+            <div className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-2xl backdrop-blur">
+              <div className="space-y-5">
+                <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <h3 className="text-sm font-semibold text-slate-900">Resumo do pet</h3>
+                  <p className="mt-2 text-sm text-slate-500">Histórico de serviços, observações e alertas personalizados para cada atendimento.</p>
+                </div>
+                <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <h3 className="text-sm font-semibold text-slate-900">Próximo agendamento</h3>
+                  <p className="mt-2 text-sm text-slate-500">Escolha data, horário e profissional preferido em tempo real.</p>
+                </div>
+                <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <h3 className="text-sm font-semibold text-slate-900">Assistente virtual</h3>
+                  <p className="mt-2 text-sm text-slate-500">A Luma responde dúvidas sobre serviços, horários e envia lembretes inteligentes.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-12">
+          <div className="text-center">
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Por que escolher a Banho &amp; Tosa</p>
+            <h2 className="mt-3 text-3xl font-bold text-slate-900">Tecnologia e carinho para o seu pet</h2>
+            <p className="mt-4 text-base text-slate-600">Nossos processos foram pensados para simplificar o dia a dia, oferecer transparência e deixar você sempre informado.</p>
+          </div>
+          <div className="grid gap-8 md:grid-cols-3">
+            {features.map(feature => (
+              <div key={feature.name} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-100 text-primary-700">
+                  <feature.icon className="h-6 w-6" />
+                </div>
+                <h3 className="mt-4 text-lg font-semibold text-slate-900">{feature.name}</h3>
+                <p className="mt-2 text-sm text-slate-600">{feature.description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-12 rounded-3xl border border-slate-200 bg-white p-8 shadow-lg md:grid-cols-2">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Como funciona</p>
+            <h2 className="mt-3 text-3xl font-bold text-slate-900">Agendamento em três etapas rápidas</h2>
+            <p className="mt-4 text-base text-slate-600">Com poucos cliques você confirma o próximo banho ou tosa. Nossa equipe recebe notificações automáticas e prepara tudo para o atendimento.</p>
+          </div>
+          <ol className="space-y-6">
+            {steps.map(step => (
+              <li key={step.title} className="flex items-start gap-4">
+                <SparklesIcon className="mt-1 h-6 w-6 text-primary-500" />
+                <div>
+                  <h3 className="text-lg font-semibold text-slate-900">{step.title}</h3>
+                  <p className="text-sm text-slate-600">{step.description}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="grid gap-8 md:grid-cols-2">
+          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg">
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Depoimento</p>
+            <blockquote className="mt-4 space-y-4">
+              <p className="text-lg text-slate-600">“Consigo agendar o banho da Mel em segundos e o histórico com observações ajuda muito nas tosas. A equipe é super carinhosa e a Luma tira todas as dúvidas.”</p>
+              <footer className="text-sm font-semibold text-slate-900">Mariana Costa, tutora da Mel</footer>
+            </blockquote>
+          </div>
+          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg">
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Perguntas frequentes</p>
+            <div className="mt-4 space-y-4">
+              {faqs.map(item => (
+                <details key={item.question} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                  <summary className="cursor-pointer text-sm font-semibold text-slate-900">
+                    {item.question}
+                  </summary>
+                  <p className="mt-2 text-sm text-slate-600">{item.answer}</p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="relative overflow-hidden rounded-3xl bg-primary-600 px-8 py-12 text-white">
+          <div className="absolute inset-y-0 right-0 h-full w-1/2 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.25),_transparent_60%)]" aria-hidden="true" />
+          <div className="relative z-10 grid gap-6 md:grid-cols-[2fr,1fr] md:items-center">
+            <div>
+              <h2 className="text-3xl font-bold">Pronto para transformar o banho e tosa do seu pet?</h2>
+              <p className="mt-4 text-base text-primary-50">Cadastre-se gratuitamente e comece a organizar seus agendamentos com suporte inteligente.</p>
+            </div>
+            <div className="flex flex-col items-start gap-3 md:items-end">
+              <Link
+                to={isAuthenticated ? defaultPath : '/cadastro'}
+                className="inline-flex w-full items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-primary-600 shadow-lg transition hover:bg-primary-100 md:w-auto"
+              >
+                {isAuthenticated ? 'Acessar painel' : 'Criar conta gratuita'}
+              </Link>
+              <Link to="/login" className="text-sm underline decoration-primary-200 decoration-dashed underline-offset-4">
+                Já sou cliente
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <ChatbotWidget initialOpen={false} />
+    </div>
+  )
+}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -21,7 +21,7 @@ export default function LoginPage () {
     setError('')
     try {
       await login(form)
-      navigate('/agendamentos')
+      navigate('/app/agendamentos')
     } catch (err) {
       setError(err.response?.data?.error || 'Não foi possível realizar login')
     }

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -20,7 +20,7 @@ export default function RegisterPage () {
     try {
       await register(form)
       await login({ email: form.email, senha: form.senha })
-      navigate('/agendamentos')
+      navigate('/app/agendamentos')
     } catch (err) {
       setError(err.response?.data?.error || 'Não foi possível realizar o cadastro')
     }

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -9,6 +9,7 @@ import SchedulePage from '../pages/SchedulePage'
 import AppointmentsPage from '../pages/AppointmentsPage'
 import DashboardPage from '../pages/DashboardPage'
 import ManagementPage from '../pages/ManagementPage'
+import LandingPage from '../pages/LandingPage'
 
 function ProtectedRoute ({ children }) {
   const { isAuthenticated } = useAuth()
@@ -21,17 +22,21 @@ function ProtectedRoute ({ children }) {
 function PublicOnlyRoute ({ children }) {
   const { isAuthenticated, user } = useAuth()
   if (isAuthenticated) {
-    return <Navigate to={user?.role === 'profissional' ? '/gestao' : '/agendamentos'} replace />
+    const defaultPath = user?.role === 'profissional' ? '/app/gestao' : '/app/agendamentos'
+    return <Navigate to={defaultPath} replace />
   }
   return children
 }
 
 export default function AppRoutes () {
-  const { user } = useAuth()
-  const defaultAuthenticatedPath = user?.role === 'profissional' ? '/gestao' : '/agendamentos'
+  const { user, isAuthenticated } = useAuth()
+  const defaultNestedPath = user?.role === 'profissional' ? 'gestao' : 'agendamentos'
+  const defaultAuthenticatedPath = `/app/${defaultNestedPath}`
+  const fallbackPath = isAuthenticated ? defaultAuthenticatedPath : '/'
 
   return (
     <Routes>
+      <Route path="/" element={<LandingPage />} />
       <Route
         path="/login"
         element={(
@@ -49,21 +54,21 @@ export default function AppRoutes () {
         )}
       />
       <Route
-        path="/"
+        path="/app"
         element={(
           <ProtectedRoute>
             <Layout />
           </ProtectedRoute>
         )}
       >
-        <Route index element={<Navigate to={defaultAuthenticatedPath} replace />} />
+        <Route index element={<Navigate to={defaultNestedPath} replace />} />
         <Route path="agendamentos" element={<AppointmentsPage />} />
         <Route path="agendar" element={<SchedulePage />} />
         <Route path="pets" element={<PetsPage />} />
         <Route path="dashboard" element={<DashboardPage />} />
         <Route path="gestao" element={<ManagementPage />} />
       </Route>
-      <Route path="*" element={<Navigate to={defaultAuthenticatedPath} replace />} />
+      <Route path="*" element={<Navigate to={fallbackPath} replace />} />
     </Routes>
   )
 }


### PR DESCRIPTION
## Summary
- add chatbot controller, route and service so the assistant can answer sobre serviços, horários e contato
- criar landing page institucional com seções de destaque e integrar o novo widget de chatbot
- atualizar rotas e navegação para expor a landing page pública e mover o painel autenticado para /app

## Testing
- npm run build *(fails: react-scripts não instalado porque npm install é bloqueado no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0f0d806c8327b5f7f6195a04dc83