### PR TITLE
Fix circular dependency in security configuration

### DIFF
--- a/backend/src/main/java/com/pibanhotosa/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pibanhotosa/config/SecurityConfig.java
@@ -22,15 +22,9 @@ import java.util.List;
 @Configuration
 @EnableMethodSecurity
 public class SecurityConfig {
-
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
-
-    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
-        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
-    }
-
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())


### PR DESCRIPTION
## Summary
- inject the JWT authentication filter directly into the security filter chain bean to avoid constructor wiring
- remove the stateful field from `SecurityConfig` to break the circular dependency with `UsuarioService`

## Testing
- `mvn test` *(fails: repository download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb6e810748327a48cb9a090dd4d06