### PR TITLE
Fix missing ClockIcon import on landing page

### DIFF
--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import {
   CameraIcon,
+  ClockIcon,
   ChatBubbleBottomCenterTextIcon,
   HeartIcon,
   MapPinIcon,


### PR DESCRIPTION
## Summary
- import the ClockIcon component from Heroicons in the landing page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddbcbac9a08327a907b0f06925b635