### PR TITLE
Fix Angular compilation errors by updating TypeScript config

### DIFF
--- a/frontend/src/app/infrastructure/http/auth.http.repository.ts
+++ b/frontend/src/app/infrastructure/http/auth.http.repository.ts
@@ -21,13 +21,19 @@ export class AuthHttpRepository implements AuthRepository {
   login(email: string, password: string): Observable<User> {
     return this.http
       .post<AuthResponse>(`${this.env.apiUrl}/auth/login`, { email, password })
-      .pipe(tap(response => this.storage.save(response.token)), map(response => ({ ...response.user, token: response.token })));
+      .pipe(
+        tap((response: AuthResponse) => this.storage.save(response.token)),
+        map((response: AuthResponse) => ({ ...response.user, token: response.token }))
+      );
   }
 
   register(name: string, email: string, password: string): Observable<User> {
     return this.http
       .post<AuthResponse>(`${this.env.apiUrl}/auth/register`, { name, email, password })
-      .pipe(tap(response => this.storage.save(response.token)), map(response => ({ ...response.user, token: response.token })));
+      .pipe(
+        tap((response: AuthResponse) => this.storage.save(response.token)),
+        map((response: AuthResponse) => ({ ...response.user, token: response.token }))
+      );
   }
 
   getProfile(): Observable<User> {

--- a/frontend/src/app/presentation/pages/dashboard-page/dashboard-page.component.ts
+++ b/frontend/src/app/presentation/pages/dashboard-page/dashboard-page.component.ts
@@ -135,8 +135,12 @@ export class DashboardPageComponent implements OnInit {
   readonly loading = signal(false);
 
   readonly totalAppointments = computed(() => this.appointments()?.length ?? 0);
-  readonly doneAppointments = computed(() => (this.appointments() ?? []).filter(item => item.status === 'done').length);
-  readonly cancelledAppointments = computed(() => (this.appointments() ?? []).filter(item => item.status === 'cancelled').length);
+  readonly doneAppointments = computed(
+    () => (this.appointments() ?? []).filter((item: Appointment) => item.status === 'done').length
+  );
+  readonly cancelledAppointments = computed(
+    () => (this.appointments() ?? []).filter((item: Appointment) => item.status === 'cancelled').length
+  );
 
   ngOnInit(): void {
     this.load();
@@ -145,7 +149,7 @@ export class DashboardPageComponent implements OnInit {
   load(): void {
     this.loading.set(true);
     this.listAppointmentsUseCase.execute().subscribe({
-      next: appointments => {
+      next: (appointments: Appointment[]) => {
         this.appointments.set(appointments);
         this.loading.set(false);
       },
@@ -158,9 +162,9 @@ export class DashboardPageComponent implements OnInit {
 
   updateStatus(event: { id: string; status: Appointment['status'] }): void {
     this.updateAppointmentStatusUseCase.execute(event.id, event.status).subscribe({
-      next: updated => {
+      next: (updated: Appointment) => {
         const current = this.appointments() ?? [];
-        this.appointments.set(current.map(item => (item.id === updated.id ? updated : item)));
+        this.appointments.set(current.map((item: Appointment) => (item.id === updated.id ? updated : item)));
       }
     });
   }

--- a/frontend/src/app/presentation/pages/pets-page/pets-page.component.ts
+++ b/frontend/src/app/presentation/pages/pets-page/pets-page.component.ts
@@ -202,7 +202,7 @@ export class PetsPageComponent implements OnInit {
 
   load(): void {
     this.listPetsUseCase.execute().subscribe({
-      next: pets => this.pets.set(pets),
+      next: (pets: Pet[]) => this.pets.set(pets),
       error: () => this.pets.set([])
     });
   }
@@ -214,7 +214,7 @@ export class PetsPageComponent implements OnInit {
 
     this.creating.set(true);
     this.createPetUseCase.execute(this.form.getRawValue()).subscribe({
-      next: pet => {
+      next: (pet: Pet) => {
         this.creating.set(false);
         this.form.reset();
         this.pets.set([...(this.pets() ?? []), pet]);

--- a/frontend/src/app/presentation/pages/schedule-page/schedule-page.component.ts
+++ b/frontend/src/app/presentation/pages/schedule-page/schedule-page.component.ts
@@ -205,7 +205,7 @@ export class SchedulePageComponent implements OnInit {
 
   load(): void {
     this.listAppointmentsUseCase.execute().subscribe({
-      next: appointments => this.appointments.set(appointments),
+      next: (appointments: Appointment[]) => this.appointments.set(appointments),
       error: () => this.appointments.set([])
     });
   }
@@ -220,7 +220,7 @@ export class SchedulePageComponent implements OnInit {
     this.scheduleAppointmentUseCase
       .execute({ petId, petName, ownerName, service, scheduledAt })
       .subscribe({
-        next: appointment => {
+        next: (appointment: Appointment) => {
           this.creating.set(false);
           this.form.reset();
           this.appointments.set([appointment, ...(this.appointments() ?? [])]);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -22,4 +22,4 @@ bootstrapApplication(AppComponent, {
     PET_HTTP_REPOSITORY_PROVIDER,
     APPOINTMENT_HTTP_REPOSITORY_PROVIDER
   ]
-}).catch(err => console.error(err));
+}).catch((err: unknown) => console.error(err));

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,7 +10,13 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "useDefineForClassFields": false,
+    "experimentalDecorators": true
   },
   "angularCompilerOptions": {
     "disableTypeScriptVersionCheck": true


### PR DESCRIPTION
## Summary
- configure the TypeScript compiler to target ES2022 modules with Node-style resolution so Angular packages resolve during compilation
- add explicit typings to observable callbacks and computed helpers in dashboard, pets, and schedule pages to satisfy strict mode
- type the auth HTTP repository stream helpers and bootstrap error handling to keep strict type checking happy

## Testing
- npm run build *(fails: Angular CLI binary unavailable because npm install cannot complete due to 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc090c3c48327b8a83d2143881d8a